### PR TITLE
Tso500 ctdna full pipeline

### DIFF
--- a/config/project.yaml
+++ b/config/project.yaml
@@ -341,6 +341,26 @@ projects:
             ica_workflow_version_name: 1.0.0
             modification_time: 2021-08-09T05:18:25UTC
             run_instances: []
+      - name: umccrise-pipeline
+        path: umccrise-pipeline
+        ica_workflow_name: umccrise-pipeline_dev-wf
+        ica_workflow_id: wfl.b10e715320844774b730b12c6e7fe185
+        versions:
+          - name: 1.2.1--0
+            path: 1.2.1--0/umccrise-pipeline__1.2.1--0.cwl
+            ica_workflow_version_name: 1.2.1--0
+            modification_time: 2021-08-11T10:38:33UTC
+            run_instances: []
+      - name: tso500-ctdna-with-post-processing-pipeline
+        path: tso500-ctdna-with-post-processing-pipeline
+        ica_workflow_name: tso500-ctdna-with-post-processing-pipeline_dev-wf
+        ica_workflow_id: wfl.b0be3d1bbd8140bbaa64038f0eb8f7c2
+        versions:
+          - name: 1.1.0--1.0.0
+            path: 1.1.0--1.0.0/tso500-ctdna-with-post-processing-pipeline__1.1.0--1.0.0.cwl
+            ica_workflow_version_name: 1.1.0--1.0.0
+            modification_time: 2021-08-12T01:23:11UTC
+            run_instances: []
   - project_name: production_workflows
     project_id: fdd48e11-cdcc-46a9-b5ac-dee3a4c5f19d
     project_description: |
@@ -581,4 +601,14 @@ projects:
             path: 1.0.0/tso500-ctdna-post-processing-pipeline__1.0.0.cwl
             ica_workflow_version_name: 1.0.0
             modification_time: 2021-08-10T06:43:29UTC
+            run_instances: []
+      - name: tso500-ctdna-with-post-processing-pipeline
+        path: tso500-ctdna-with-post-processing-pipeline
+        ica_workflow_name: tso500-ctdna-with-post-processing-pipeline_clb-ilmn-dev_wf
+        ica_workflow_id: wfl.8660595a483040cea0bb175989dd97b1
+        versions:
+          - name: 1.1.0--1.0.0
+            path: 1.1.0--1.0.0/tso500-ctdna-with-post-processing-pipeline__1.1.0--1.0.0.cwl
+            ica_workflow_version_name: 1.1.0--1.0.0
+            modification_time: 2021-08-12T01:23:15UTC
             run_instances: []

--- a/config/project.yaml
+++ b/config/project.yaml
@@ -610,5 +610,5 @@ projects:
           - name: 1.1.0--1.0.0
             path: 1.1.0--1.0.0/tso500-ctdna-with-post-processing-pipeline__1.1.0--1.0.0.cwl
             ica_workflow_version_name: 1.1.0--1.0.0
-            modification_time: 2021-08-12T01:23:15UTC
+            modification_time: 2021-08-16T11:27:53UTC
             run_instances: []

--- a/config/project.yaml
+++ b/config/project.yaml
@@ -611,4 +611,5 @@ projects:
             path: 1.1.0--1.0.0/tso500-ctdna-with-post-processing-pipeline__1.1.0--1.0.0.cwl
             ica_workflow_version_name: 1.1.0--1.0.0
             modification_time: 2021-08-18T09:38:26UTC
-            run_instances: []
+            run_instances:
+              - wfr.d92a2d28bbfe46fe878f6513fdb06723

--- a/config/project.yaml
+++ b/config/project.yaml
@@ -610,5 +610,5 @@ projects:
           - name: 1.1.0--1.0.0
             path: 1.1.0--1.0.0/tso500-ctdna-with-post-processing-pipeline__1.1.0--1.0.0.cwl
             ica_workflow_version_name: 1.1.0--1.0.0
-            modification_time: 2021-08-16T21:29:26UTC
+            modification_time: 2021-08-18T09:38:26UTC
             run_instances: []

--- a/config/project.yaml
+++ b/config/project.yaml
@@ -610,5 +610,5 @@ projects:
           - name: 1.1.0--1.0.0
             path: 1.1.0--1.0.0/tso500-ctdna-with-post-processing-pipeline__1.1.0--1.0.0.cwl
             ica_workflow_version_name: 1.1.0--1.0.0
-            modification_time: 2021-08-16T11:27:53UTC
+            modification_time: 2021-08-16T21:29:26UTC
             run_instances: []

--- a/config/project.yaml
+++ b/config/project.yaml
@@ -519,6 +519,16 @@ projects:
             ica_workflow_version_name: 3.7.5--67a9d2b
             modification_time: 2021-07-02T05:02:57UTC
             run_instances: []
+      - name: tso500-ctdna-with-post-processing-pipeline
+        path: tso500-ctdna-with-post-processing-pipeline
+        ica_workflow_name: tso500-ctdna-with-post-processing-pipeline_prod-wf
+        ica_workflow_id: wfl.230846758ccf42e3831283ab0e45af0a
+        versions:
+          - name: 1.1.0--1.0.0
+            path: 1.1.0--1.0.0/tso500-ctdna-with-post-processing-pipeline__1.1.0--1.0.0.cwl
+            ica_workflow_version_name: 1.1.0--1.0.0--__GIT_COMMIT_ID__
+            modification_time:
+            run_instances: []
   - project_name: collab-illumina-dev_workflows
     project_id: dddd6c29-24d3-49f4-91c0-7e818b3c0a21
     project_description: |

--- a/config/run.yaml
+++ b/config/run.yaml
@@ -325,3 +325,259 @@ runs:
         task_stop_time: 1626511193
         task_duration: 459
         task_metrics: eJyLjgUAARUAuQ==
+  - ica_workflow_run_instance_id: wfr.d92a2d28bbfe46fe878f6513fdb06723
+    ica_project_launch_context_id: 30f09dfb-10e3-43b4-9056-07c8623b96a3
+    ica_workflow_id: wfl.8660595a483040cea0bb175989dd97b1
+    ica_workflow_name: tso500-ctdna-with-post-processing-pipeline_clb-ilmn-dev_wf
+    ica_workflow_version_name: 1.1.0--1.0.0
+    ica_workflow_run_name: tso500-ctdna-full-start-end-workflow-test
+    ica_input: eJzVVF9r2zAQ/ypFz7Mle5SVvnkOyQbp2GqPboxxKPIlE5UlV5LTZCHfvZKdBjYGTQcd7MnCp/v9u7N3pLF8hRqUFKgdwi1uyeXZjgjFnQsnMpUKyaszoozgXhod360ad0mpMErxRSKV6lupedLgmo5oyQGNCu+doY/YfSuETf3Gk30AXHLn7wKv82DNfeT6tiOKawynLNQt8gayZ4rZBiGaegygDfec2l7TnLE8y6Fg7IK9AZblF1C8Oy9vbibVl690WlT1J1qh5Q7voDRtB1e9hyu5gWKaweRDARa77OkbUGUwZyyD6wzCIx38paufg9nBTP4/msn/YGYlmyj2SZQ0S4tZOSvqYpbWdVHX5awmA4BaRIDP+labez2XC8vtdqy49iRosv8+xOpMbwU6aKT9Nd2JtCi8GWFPW16LS7SoBSZD3IcvI2wwCN/omL9JoieWvqZjEL0GqZcGNq168dle9/p94Eoj1yN5xy1v0aN1/0rCxyPjUYjjbafQ/UD0L66gGriqyJUKt/6dH7owQ7mJRG/LeWn0Gq2PEsIQzxmDw9XxX9NxaeHETSZHnr/o0CGx5/b4bTf0hFJY9f0DkYTcZQ==
+    ica_output: eJzlWltv2zYU/iuFn2uZulAS++aly1sKrAn2MhQCJVEKN4r0RDqXBvnvo1LJ9WTLNgmjaGkYgUNZ/A75fTyHh5eXmVir1VplLZFrpmRW0nb24d3LjIkCKyq4LszqUn5YLB6r1itRgIMySPO8IlFckTRJqxj6YVXmIE6CcKGkgADMC1VyPK/WjM2lwq2aE17OH0X7T8XE41wRqRbf7MrF52+GZ+/fzXIsCccN6WxuPe4etUKo7vFQJk+bYsGwlF3hI21JoUT73D2V9GuHw3UTXnVxt5dZ/pxJ3KxY99pfLxMwP5qGxS1pNQv/ZleiWWU3usk39ClbXvvZx09L3fyVPybqpAqMSkV5PerpNdWd/yk7efwNb8loza8EY3glyfVa6vZfYcZImzVEtbSQ3t9ScK/+akyYGXQ/0AIUw9FYPZeh0Zjv7Ooh7YqOd7itifpM6q7z4kG/XxN76Y6h9WqFgblYk9Bu65PjxlyGvlLPdgQSGMAUwtiU9DG1Ha5b3Oo/asXvULHnOA4BRCAyHtW9Uv8nmbpGclNCubYbx1t1N8HjHCz3sA4RXTCCOSk9nWqo4l7/YxU6plB68n0Uxz4ESeAbizBGdjy47CPSLtocQhp8IopSH5k7xpTaDsejSicODeEqY4TX6j6717m5fcJzDG3QB8XAWJxJbLcznkZSez1GlXv6YZQasz8guU22anJ7skeVh3QzTYzJHpCcJlv/snr+tG5y0v6JW4q5kt5DUdlQfxhqWBODJDRVYgL4QnXxVG4+Xx+H2ySyofGK7LDw2xJ1thzS6Brr1pfZ70+CZ0W//M/+uLIOXqcADjlvEhpPHwfh3famqZ4r3duzqdSDDVOOb74onILe8SP97ZI6b9uc9ruz+wB6FdIQmYuwhea2W9yQtiblbYMZ20TumnDREOsk4CTI7ylwGieh8bL9iJEL18wuQTgZdrOBi3zjDfPTRofDGcO+/p/T03ZczPcD/QHmQXAC/fJ869xOtT/tjtLoPGHwUt1oyblQWJHSPos4FXVwLT15RWEAzPPwo4Yuzst2eNbf5/G3SeTvh/ToLNFx71DZFrGz65CKt28XZZYcs2dJZY9s73xH4TYTWuxHxpt5B+Dd9rW7m9+yuxYX9vcn9kMMGTwKofEB8wjxVxaAPNCScN0Rq0sT5rU3uz8oTKId5k/H+6XPOc1o23e+aYcwzBgRQklqz/3keeaX1y/vN9cSu+uImu9MEtntRmS07F6UknuwipKIgKDwQRARDBGM/RyTME2ATiPx2xn2CKQSrCRtj6ELXhzGKQoRKdJE14FFHIEKpCWK/QImOchnr/8BEnBLzw==
+    ica_engine_parameters: eJy9krFuwyAURX8l8pKl2GA3tpu1GdohyuD2A4h5WKgYLHjETaP8e8FRO3VNR3jnviNduGSzdR875aBH687ZdpUNwm+LYpYuF08lL0XZHo8SHmsJbdPKesMqKY60bsqqQG83lJIeheFEBq2JR+6QgBEk7ZXazgTBY/awymzAKeDdVcXN45MSx+nwT1aPMC1ObYf726JkkY38s+s5Irioan9L7gBRmSHpR3uCRPZ2Ot+6eDVxq+nh7TxBIrp4EtyJF/U8hb/RTn0t6B6ECmNiBEgedAQitbdima53djbacrFOhPoZHU7gnBLgI3O5plcB/+7hFuVGyfQ/UpwHtEu0nzVaq9NlldO8pCVlJa1YUzHGEgBmUGZxspw1OSURYbRhNaOsiaU5jsGTkftUzPUbByjy2g==
+    workflow_start_time: 1629322711
+    workflow_end_time: 1629351656
+    workflow_duration: 28944
+    ica_tasks:
+      - ica_task_run_instance_id: trn.1e530cc145154919a469e3656de79159
+        task_step_name: run_tso_ctdna_workflow_step/add_sample_type_and_pair_id_to_samplesheet_step
+        task_name: custom-create-tso500-samplesheet__1.0.0.cwl
+        task_cpus: 0.8
+        task_memory: 3
+        task_start_time: 1629323252
+        task_stop_time: 1629323681
+        task_duration: 428
+        task_metrics: eJyLjgUAARUAuQ==
+      - ica_task_run_instance_id: trn.80595391ae704bdc8395e0ce44dcf6c6
+        task_step_name: run_tso_ctdna_workflow_step/run_tso500_ctdna_demultiplex_workflow_step
+        task_name: tso500-ctdna-demultiplex-workflow__1.1.0--120.cwl
+        task_cpus: 7.5
+        task_memory: 118
+        task_start_time: 1629324004
+        task_stop_time: 1629325302
+        task_duration: 1298
+        task_metrics: eJyLrlYqycxNLS5JzC1QslIwNDOyNDYyNTQz1VFQSi4oBQoZAFm5qbn5RZUgjp5BbSwAlFAOng==
+      - ica_task_run_instance_id: trn.70002920a4ba46c780ea5a1c42ae0813
+        task_step_name: run_tso_ctdna_workflow_step/run_tso500_ctdna_analysis_workflow_step
+        task_name: tso500-ctdna-analysis-workflow__1.1.0--120.cwl
+        task_cpus: 15.5
+        task_memory: 240
+        task_start_time: 1629325480
+        task_stop_time: 1629343989
+        task_duration: 18509
+        task_metrics: eJydm81uHTcMhV8lyDq4EEVSFPsqRRdFkUUXRoM2XRRF3j3yxqZ0cw4mA2/iAJ85OvwRxdH8+v/Hr3++fP7n6+8vXz7+8kFGT+3DbXz68PGPL/++/tdD1r9fPr/89fd/69f20G+fPvyQGuJvVHuMSo1HQmrEuy1/WMU0sLXo79b00Su2/syE2BwI6/7oCJteremBwYdMaQRziA19w/pjHtgAWDTtxZocGPJAtAxobTwEYWKTYEiS6K0q6QcG17Z+ijU5MOTuUK0O2IKrx6NBbE4YJQGjJMwGXFs8DGHemDUoiY8J3R1YktEDWptYkjHfMdutKVEyXN6weETFrOO1zTYKtilpDcfkHHVtuWGKMyB7FmubJEYSJ6fCtWFrs/l7TM7DmkAlp4gWTI6HREpOGQM+pGNrveO1NZgBs08v2JZvtv4MwrRIEvvWYbi8TiuJMw/MYAZMi+qAVjEXbM1L4sy9mBuuXNOzrk0ODIXyXJvwGzb2tTmRJAQH1yTYMCTJekjot6k1SrY09Y7XNlPQQzrxW1oUSbaYdKxktubIAa4wA7KFIHevKEHFPKXXNPXDb6gopGxR4sdDwrV1r9ndj3xDDUaq1I1qHNbgQ2rZcVaTpRcTLk1H5faygLuutCLKDzjoA7fAz+kwnHM0Y/YwR3pYsoFklIbtiRs4NNeGxTgYLdMc6zKwH7I5s4eqSmYQ/w3kP22t0/WBsF4cixdYorVJKtMF+F1bL83ND+xBToU+J8ijxYUyDsSZNtObHIsz2PRp80HWFyg+tY1dF73MxbxlL1hdgn3+4pLUQcLNQfwAz7raUkicMS7yDidNKYfyVlqS+kk4cVI/CdeF1CW4/S0uhPkPcsrqNeN4HqG6JMbqC+G83+SC6gm5kTT/UB2UcKoL5GZL5j/MBekL4JFZ1/ZA4xpzSf2AuN6431G97tJp/cQcrxOQ63s+7PbgLGFxSfxAOHXSv0xY57sJyXfGBYkzwrmSfCDcaMR/E+4rfTjZVwgXQvXEXJC8Jdzc8+iyvWykn4Cn2teDANUTcashpHpiLqiekBMeL5jLe/a6Uz+g/fa1MrHnxBzPI8gdfet1Lkk9I5z7uGVvsD5kwr5AB+tDCBc8XjDH6y7kppN+l3ApN7lJ/Y44a0rjE3Ps/Ec42rdO2C9ZF5p/mAuqJ+RUb3I8XiBng+oJOb+pi9/UZfA8glw00p8xju/TkJu87mKu1JfjpRmevliWrq7ts2BG7We/zZjgns7bXnP311gC1+Zbr2v7u55lD50BXPbeZVteb9je1uvaPn3u8E3W4uoefTznsofOAK51j7bj1aXi9VnR5UgF6bCVd6tHo0NN+E5kbZhaVnfGCjTmeYcadRe6TEU9C1+n4o6tWWPkOlUz5zKVd9QYTW6oMVrceMIhdbp2nap78WWq+w3lh8otarYblN1Sw0pstP21EJ4TDy/nnqcKDqlRY6PtpQM3QWMEdBjemkZgOfAgbQQODkJNhw7DQ9CR/RYVsLRhKprGHQoXDkKJE+Uh1eWGGtFvqbG1q9eprEE/rgV91BHr5VQJF6ghHu+Ej0SUwDfKGgPLIfD99cISFreFoVlLxIA7BMOmwMykWMDAZ1gqVpJheWdtsznMM4YJDhKK4c2WYZ1GCcbyjgOm+i3McPtBsbgTytONWUOFZJLulFkbzqyhHX4d0chpC1Nxh6rXdX6CSlKOoRzppPSj00s23JHhwpoNd2S4BUnSn05Y+lNwWSVUx/lCKMWbLqMCBiKhTGHZYVTCQkwox7GBT+45tnq63/iG9yYXNoscZ2ImLAMZ9Wh72kscVpGUg6LMussct+4Xh7rb3PrUw16HVzUXF5suenAg2axtverz+kAZWVzt3WVv0Dr0nzWpRzs5blU3bK/X4fPh9w5HGosLxxyxp+US8Ws7d9gDflhcdqYL5GzXRa/quQ1Znzm4Pg+F8bk4EJ/Wxh4vpy6Yq9tOOwZuhIty+Wg+zdtA2lqb5R1OXvf6jAExOL18feHwbu2c0sESuLBy4js+ZxB4B9ykef3CY6+AhjGROny42D8trLzt+wms6z0sb2GKRyQMqw3sqaTCmBTDW/LCwMnPxLd+Ta4+pONNebkbFQYZ5Jhj2Frglk3gnHphVBKITYMtEcO2GwRPGNiTF0ZPfqgodNLFEgf0hpt6Zk1KLTkGH8ya4OmRwA8MrHfDwQWvSFvX7ZiTB4Yc0LXMB04MXnS2booxXCe7t0YwuDZ3vbO2IewhobWxldfLktQ7Az/xkPXKwLM11Jz0emPgDGX4oYD13CS5jgWLSSSJbtdcj0bWYL5p2+YDl7F6WaDt30uStWkvp54zu3Eov36wByWBo3J7vSMCscRKGi6v+AiysK28Xu0o1fFkvsMBzcKwJN3gJqwDjwk6zgAdeIqEvzxddQvvOB3e6DKdAtsZ/OWpab0g0J4+j/Vvv30HoKe7ZA==
+      - ica_task_run_instance_id: trn.736e87d6c4e6485dbfc0f3794c9a4c25
+        task_step_name: run_tso_ctdna_workflow_step/run_tso500_ctdna_reporting_workflow_step
+        task_name: tso500-ctdna-reporting-workflow__1.1.0--120.cwl
+        task_cpus: 7.5
+        task_memory: 118
+        task_start_time: 1629344235
+        task_stop_time: 1629345251
+        task_duration: 1016
+        task_metrics: eJyLrlYqycxNLS5JzC1QslIwNDOyNDYxNTA30VFQSi4oBQoZ6BkA2bmpuflFlRBurY4CVl2GxghdhnqGqLosa2MBb5odlQ==
+      - ica_task_run_instance_id: trn.5e19bfc295f84e84bef481a657586474
+        task_step_name: run_tso_ctdna_post_processing_workflow_step/dragen_metrics_to_json_step
+        task_name: custom-tso500-align-collapse-fusion-caller-csv-metrics-to-json__1.0.0.cwl
+        task_cpus: 0.8
+        task_memory: 3
+        task_start_time: 1629346255
+        task_stop_time: 1629346693
+        task_duration: 437
+        task_metrics: eJyLjgUAARUAuQ==
+      - ica_task_run_instance_id: trn.cc56d55639fd4bf483059a51163e4603
+        task_step_name: run_tso_ctdna_post_processing_workflow_step/mosdepth_step
+        task_name: mosdepth__0.3.1.cwl
+        task_cpus: 4
+        task_memory: 14
+        task_start_time: 1629346285
+        task_stop_time: 1629346753
+        task_duration: 467
+        task_metrics: eJyLrlYqycxNLS5JzC1QslIwNDOyNDYxMzM201FQSi4oBQoZAFm5qbn5RZUgjp5BbSwAlQoOpA==
+      - ica_task_run_instance_id: trn.9beb3f8d3e5e47a5a1bc70a1cd58bc50
+        task_step_name: run_tso_ctdna_post_processing_workflow_step/compress_reporting_jsons_with_gzip_step
+        task_name: custom-gzip-file__1.0.0.cwl
+        task_cpus: 4
+        task_memory: 14
+        task_start_time: 1629346308
+        task_stop_time: 1629346693
+        task_duration: 384
+        task_metrics: eJyLjgUAARUAuQ==
+      - ica_task_run_instance_id: trn.c8fde9357d5b464f9442d045b5bcf8a4
+        task_step_name: run_tso_ctdna_post_processing_workflow_step/compress_reporting_jsons_with_gzip_step
+        task_name: custom-gzip-file__1.0.0.cwl
+        task_cpus: 4
+        task_memory: 14
+        task_start_time: 1629346313
+        task_stop_time: 1629346733
+        task_duration: 420
+        task_metrics: eJyLjgUAARUAuQ==
+      - ica_task_run_instance_id: trn.434b777bc7f54af3b07b3f58ac9ac227
+        task_step_name: run_tso_ctdna_post_processing_workflow_step/compress_reporting_jsons_with_gzip_step
+        task_name: custom-gzip-file__1.0.0.cwl
+        task_cpus: 4
+        task_memory: 14
+        task_start_time: 1629346310
+        task_stop_time: 1629346693
+        task_duration: 382
+        task_metrics: eJyLjgUAARUAuQ==
+      - ica_task_run_instance_id: trn.eab62b404c8a429cbf7863f413c8d0ff
+        task_step_name: run_tso_ctdna_post_processing_workflow_step/compress_vcf_files_step
+        task_name: bgzip__1.12.0.cwl
+        task_cpus: 4
+        task_memory: 14
+        task_start_time: 1629346332
+        task_stop_time: 1629346713
+        task_duration: 381
+        task_metrics: eJyLjgUAARUAuQ==
+      - ica_task_run_instance_id: trn.d29c3d4faaa94b36b69d3c4360fdf982
+        task_step_name: run_tso_ctdna_post_processing_workflow_step/compress_vcf_files_step
+        task_name: bgzip__1.12.0.cwl
+        task_cpus: 4
+        task_memory: 14
+        task_start_time: 1629346332
+        task_stop_time: 1629346672
+        task_duration: 340
+        task_metrics: eJyLjgUAARUAuQ==
+      - ica_task_run_instance_id: trn.48148ff7e95340a5aa7223048c34c241
+        task_step_name: run_tso_ctdna_post_processing_workflow_step/compress_vcf_files_step
+        task_name: bgzip__1.12.0.cwl
+        task_cpus: 4
+        task_memory: 14
+        task_start_time: 1629346336
+        task_stop_time: 1629346693
+        task_duration: 356
+        task_metrics: eJyLjgUAARUAuQ==
+      - ica_task_run_instance_id: trn.eaa2df4a73d8495c8e48d96be11fdfb7
+        task_step_name: run_tso_ctdna_post_processing_workflow_step/make_per_coverage_threshold_qc_step
+        task_name: custom-tso500-make-region-coverage-qc__1.0.0.cwl
+        task_cpus: 1.3
+        task_memory: 4.5
+        task_start_time: 1629347006
+        task_stop_time: 1629347114
+        task_duration: 107
+        task_metrics: eJyLjgUAARUAuQ==
+      - ica_task_run_instance_id: trn.d7414ce634f64fbcad8a76a84110c96f
+        task_step_name: run_tso_ctdna_post_processing_workflow_step/make_exon_coverage_qc_step
+        task_name: custom-tso500-make-exon-coverage-qc__1.0.0.cwl
+        task_cpus: 1.3
+        task_memory: 4.5
+        task_start_time: 1629347006
+        task_stop_time: 1629347114
+        task_duration: 108
+        task_metrics: eJyLjgUAARUAuQ==
+      - ica_task_run_instance_id: trn.ed9cda77f9884582989604eef3186766
+        task_step_name: run_tso_ctdna_post_processing_workflow_step/gather_compressed_reporting_json_files_into_tar_step
+        task_name: custom-tar-file-list__1.0.0.cwl
+        task_cpus: 1.3
+        task_memory: 4.5
+        task_start_time: 1629347037
+        task_stop_time: 1629347134
+        task_duration: 96
+        task_metrics: eJyLjgUAARUAuQ==
+      - ica_task_run_instance_id: trn.9b578d8947964608b0bcf7f6fcafcb9f
+        task_step_name: run_tso_ctdna_post_processing_workflow_step/index_vcf_files_step
+        task_name: tabix__0.2.6.cwl
+        task_cpus: 1.3
+        task_memory: 4.5
+        task_start_time: 1629347091
+        task_stop_time: 1629347194
+        task_duration: 103
+        task_metrics: eJyLjgUAARUAuQ==
+      - ica_task_run_instance_id: trn.87fc84b3c13041609ea751743c04d411
+        task_step_name: run_tso_ctdna_post_processing_workflow_step/index_vcf_files_step
+        task_name: tabix__0.2.6.cwl
+        task_cpus: 1.3
+        task_memory: 4.5
+        task_start_time: 1629347089
+        task_stop_time: 1629347194
+        task_duration: 104
+        task_metrics: eJyLrlYqycxNLS5JzC1QslIwNDOyNDYxNzQy0lFQSi4oBQoZAFm5qbn5RZUgjp5BbSwAlAYOmw==
+      - ica_task_run_instance_id: trn.cbbe700807c1490dbae447c9b2612ecb
+        task_step_name: run_tso_ctdna_post_processing_workflow_step/index_vcf_files_step
+        task_name: tabix__0.2.6.cwl
+        task_cpus: 1.3
+        task_memory: 4.5
+        task_start_time: 1629347090
+        task_stop_time: 1629347194
+        task_duration: 103
+        task_metrics: eJyLjgUAARUAuQ==
+      - ica_task_run_instance_id: trn.181dc18ad36d4af5ad484650b3bb44e5
+        task_step_name: run_tso_ctdna_post_processing_workflow_step/convert_metric_csvs_into_json_gzip_step
+        task_name: custom-tsv-to-json__1.0.0.cwl
+        task_cpus: 1.3
+        task_memory: 4.5
+        task_start_time: 1629347369
+        task_stop_time: 1629347475
+        task_duration: 105
+        task_metrics: eJyLjgUAARUAuQ==
+      - ica_task_run_instance_id: trn.c07ea84e74e9493fa47a5922a4ba1411
+        task_step_name: run_tso_ctdna_post_processing_workflow_step/convert_metric_csvs_into_json_gzip_step
+        task_name: custom-tsv-to-json__1.0.0.cwl
+        task_cpus: 1.3
+        task_memory: 4.5
+        task_start_time: 1629347372
+        task_stop_time: 1629347475
+        task_duration: 102
+        task_metrics: eJyLjgUAARUAuQ==
+      - ica_task_run_instance_id: trn.737271cbab6f48c796f3e1cf20f5cdd0
+        task_step_name: run_tso_ctdna_post_processing_workflow_step/convert_metric_csvs_into_json_gzip_step
+        task_name: custom-tsv-to-json__1.0.0.cwl
+        task_cpus: 1.3
+        task_memory: 4.5
+        task_start_time: 1629347370
+        task_stop_time: 1629347475
+        task_duration: 105
+        task_metrics: eJyLjgUAARUAuQ==
+      - ica_task_run_instance_id: trn.c6cb07cb3ec64f65b8644b02d165aac8
+        task_step_name: run_tso_ctdna_post_processing_workflow_step/convert_metric_csvs_into_json_gzip_step
+        task_name: custom-tsv-to-json__1.0.0.cwl
+        task_cpus: 1.3
+        task_memory: 4.5
+        task_start_time: 1629347369
+        task_stop_time: 1629347475
+        task_duration: 106
+        task_metrics: eJyLjgUAARUAuQ==
+      - ica_task_run_instance_id: trn.091358d816bb432a925027faad6740d9
+        task_step_name: run_tso_ctdna_post_processing_workflow_step/convert_metric_csvs_into_json_gzip_step
+        task_name: custom-tsv-to-json__1.0.0.cwl
+        task_cpus: 1.3
+        task_memory: 4.5
+        task_start_time: 1629347371
+        task_stop_time: 1629347475
+        task_duration: 103
+        task_metrics: eJyLjgUAARUAuQ==
+      - ica_task_run_instance_id: trn.4c154143f27c4d86b35a65d017993676
+        task_step_name: run_tso_ctdna_post_processing_workflow_step/gather_compressed_vcf_files_into_tar_step
+        task_name: custom-tar-vcf-file-list__1.0.0.cwl
+        task_cpus: 1.3
+        task_memory: 4.5
+        task_start_time: 1629347595
+        task_stop_time: 1629347695
+        task_duration: 100
+        task_metrics: eJyLjgUAARUAuQ==
+      - ica_task_run_instance_id: trn.4172890c7bec462da17a39ca501e1a7b
+        task_step_name: run_tso_ctdna_post_processing_workflow_step/gather_compressed_metric_json_files_into_tar_step
+        task_name: custom-tar-file-list__1.0.0.cwl
+        task_cpus: 1.3
+        task_memory: 4.5
+        task_start_time: 1629347812
+        task_stop_time: 1629347916
+        task_duration: 103
+        task_metrics: eJyLjgUAARUAuQ==
+      - ica_task_run_instance_id: trn.4b6ed414d40644b6a6beecc84afa9b3c
+        task_step_name: run_tso_ctdna_post_processing_workflow_step/create_output_directory
+        task_name: custom-create-directory__2.0.0.cwl
+        task_cpus: 4
+        task_memory: 14
+        task_start_time: 1629348438
+        task_stop_time: 1629348937
+        task_duration: 498
+        task_metrics: eJyLjgUAARUAuQ==
+      - ica_task_run_instance_id: trn.a83601c7aaac4eb9ab469a5fc75fc435
+        task_step_name: create_final_output_directory
+        task_name: custom-create-directory__2.0.0.cwl
+        task_cpus: 4
+        task_memory: 14
+        task_start_time: 1629349778
+        task_stop_time: 1629350138
+        task_duration: 359
+        task_metrics: eJyLjgUAARUAuQ==

--- a/config/workflow.yaml
+++ b/config/workflow.yaml
@@ -100,6 +100,6 @@ workflows:
     versions:
       - name: 1.1.0--1.0.0
         path: 1.1.0--1.0.0/tso500-ctdna-with-post-processing-pipeline__1.1.0--1.0.0.cwl
-        md5sum: b3a63916938f3e3152a428f2878a06c9
+        md5sum: 7e4ff1ebc2e202f7e8e80097cc0bb0fe
     categories:
       - tso500

--- a/config/workflow.yaml
+++ b/config/workflow.yaml
@@ -88,3 +88,18 @@ workflows:
         md5sum: e4c11f3b6ccb53a856deca1a05fc18e1
     categories:
       - tso500
+  - name: umccrise-pipeline
+    path: umccrise-pipeline
+    versions:
+      - name: 1.2.1--0
+        path: 1.2.1--0/umccrise-pipeline__1.2.1--0.cwl
+        md5sum: f343dd987bd33e5c13573eb309228cd2
+    categories: []
+  - name: tso500-ctdna-with-post-processing-pipeline
+    path: tso500-ctdna-with-post-processing-pipeline
+    versions:
+      - name: 1.1.0--1.0.0
+        path: 1.1.0--1.0.0/tso500-ctdna-with-post-processing-pipeline__1.1.0--1.0.0.cwl
+        md5sum: 887bd33e3382b35c8e788ed0c78adc80
+    categories:
+      - tso500

--- a/config/workflow.yaml
+++ b/config/workflow.yaml
@@ -100,6 +100,6 @@ workflows:
     versions:
       - name: 1.1.0--1.0.0
         path: 1.1.0--1.0.0/tso500-ctdna-with-post-processing-pipeline__1.1.0--1.0.0.cwl
-        md5sum: 887bd33e3382b35c8e788ed0c78adc80
+        md5sum: b3a63916938f3e3152a428f2878a06c9
     categories:
       - tso500

--- a/config/workflow.yaml
+++ b/config/workflow.yaml
@@ -85,7 +85,7 @@ workflows:
     versions:
       - name: 1.0.0
         path: 1.0.0/tso500-ctdna-post-processing-pipeline__1.0.0.cwl
-        md5sum: e4c11f3b6ccb53a856deca1a05fc18e1
+        md5sum: 1337811eedededc771cbb1e600448fb9
     categories:
       - tso500
   - name: umccrise-pipeline
@@ -100,6 +100,6 @@ workflows:
     versions:
       - name: 1.1.0--1.0.0
         path: 1.1.0--1.0.0/tso500-ctdna-with-post-processing-pipeline__1.1.0--1.0.0.cwl
-        md5sum: 7e4ff1ebc2e202f7e8e80097cc0bb0fe
+        md5sum: 8b6c10d7e232b1a5b932d5038ad50ce7
     categories:
       - tso500

--- a/expressions/get-attr-from-tso500-sample-object/1.0.0/get-attr-from-tso500-sample-object__1.0.0.cwl
+++ b/expressions/get-attr-from-tso500-sample-object/1.0.0/get-attr-from-tso500-sample-object__1.0.0.cwl
@@ -1,0 +1,59 @@
+cwlVersion: v1.1
+class: ExpressionTool
+
+# Extensions
+$namespaces:
+    s: https://schema.org/
+    ilmn-tes: http://platform.illumina.com/rdf/ica/
+$schemas:
+  - https://schema.org/version/latest/schemaorg-current-http.rdf
+
+# Metadata
+s:author:
+    class: s:Person
+    s:name: Alexis Lucattini
+    s:email: Alexis.Lucattini@umccr.org
+    s:identifier: https://orcid.org/0000-0001-9754-647X
+
+# ID/Docs
+id: get-attr-from-tso500-sample-object--1.0.0
+label: get-attr-from-tso500-sample-object v(1.0.0)
+doc: |
+    Documentation for get-attr-from-tso500-sample-object v1.0.0
+
+# Requirements
+requirements:
+  InlineJavascriptRequirement: {}
+  SchemaDefRequirement:
+    types:
+      - $import: ../../../schemas/tso500-sample/1.0.0/tso500-sample__1.0.0.yaml
+
+inputs:
+  tso500_sample_object:
+    label: tso500 sample object
+    doc: |
+      TSO500 sample object
+    type: ../../../schemas/tso500-sample/1.0.0/tso500-sample__1.0.0.yaml#tso500-sample
+  attribute_name:
+    label: name of the attribute
+    doc: |
+      TSO500 sample object
+    type: string
+
+outputs:
+  attribute_value:
+    label: attribute value
+    doc: |
+      Value of the attribute
+    type: string
+
+expression: >-
+  ${
+    var attribute_value = null;
+    for (var key in inputs.tso500_sample_object){
+      if (key === inputs.attribute_name){
+        attribute_value = inputs.tso500_sample_object[key];
+      }
+    }
+    return {"attribute_value": attribute_value};
+  }

--- a/expressions/get-custom-output-dir-entry-for-tso500-post-processing/1.0.0/get-custom-output-dir-entry-for-tso500-post-processing__1.0.0.cwl
+++ b/expressions/get-custom-output-dir-entry-for-tso500-post-processing/1.0.0/get-custom-output-dir-entry-for-tso500-post-processing__1.0.0.cwl
@@ -80,10 +80,10 @@ inputs:
       * The raw bam file
       * The clean-stitched bam file
     type: Directory
-  stiched_realigned_dir:
-    label: stiched realigned caller directory
+  variant_caller_dir:
+    label: Variant caller directory
     doc: |
-      The stitched realigned directory
+      The variant caller directory
       We collect the following outputs from this directory -
       * The clean-stitched bam file
     type: Directory
@@ -151,10 +151,10 @@ expression: >-
                                                                            ],
                                                                            null,
                                                                            "top_dir"),
-              get_custom_output_dir_entry_from_directory_and_file_str_list(inputs.stiched_realigned_dir,
+              get_custom_output_dir_entry_from_directory_and_file_str_list(inputs.variant_caller_dir,
                                                                            [
-                                                                             inputs.sample_id + ".stitched.bam",
-                                                                             inputs.sample_id + ".stitched.bam.bai"
+                                                                             inputs.sample_id + ".cleaned.stitched.bam",
+                                                                             inputs.sample_id + ".cleaned.stitched.bam.bai"
                                                                            ],
                                                                            null,
                                                                            "top_dir"),

--- a/expressions/get-custom-output-dir-entry-for-tso500-with-post-processing/1.0.0/get-custom-output-dir-entry-for-tso500-with-post-processing__1.0.0.cwl
+++ b/expressions/get-custom-output-dir-entry-for-tso500-with-post-processing/1.0.0/get-custom-output-dir-entry-for-tso500-with-post-processing__1.0.0.cwl
@@ -1,0 +1,128 @@
+cwlVersion: v1.1
+class: ExpressionTool
+
+# Extensions
+$namespaces:
+    s: https://schema.org/
+    ilmn-tes: http://platform.illumina.com/rdf/ica/
+$schemas:
+  - https://schema.org/version/latest/schemaorg-current-http.rdf
+
+# Metadata
+s:author:
+    class: s:Person
+    s:name: Alexis Lucattini
+    s:email: Alexis.Lucattini@umccr.org
+    s:identifier: https://orcid.org/0000-0001-9754-647X
+
+# ID/Docs
+id: get-custom-output-dir-entry-for-tso500-with-post-processing--1.0.0
+label: get-custom-output-dir-entry-for-tso500-with-post-processing v(1.0.0)
+doc: |
+    Create a custom-output-dir-entry 2.0.0 schema for the files and directories in the tso500 post-processing pipeline.
+
+requirements:
+  SchemaDefRequirement:
+    types:
+      - $import: ../../../schemas/custom-output-dir-entry/2.0.0/custom-output-dir-entry__2.0.0.yaml
+  InlineJavascriptRequirement:
+    expressionLib:
+      # Type 1 of the custom-output-dir-entry input schema - used for align_collapse_fusion_caller_dir, merged_annotation_dir and stitched_realigned inputs
+      - var get_custom_output_dir_entry_from_directory_and_file_str_list = function(dir_obj, files_list_str, collection_name, copy_method){
+          /*
+          Create the schema object with the directory, files_list_str and the collection name and copy method
+          */
+          return {
+            "collection_name":collection_name,
+            "copy_method":copy_method,
+            "dir":dir_obj,
+            "files_list_str":files_list_str
+          };
+        }
+      # Type 2 of the custom-output-dir-entry input schema - used for coverage_qc_file input and dragen_metrics_compressed_json_file input
+      - var get_custom_output_dir_entry_from_file_list = function(file_list, collection_name, copy_method){
+          /*
+          Create the schema object with the file list, collection name and copy method
+          */
+          return {
+            "collection_name":collection_name,
+            "copy_method":copy_method,
+            "file_list":file_list
+          };
+        }
+      # Type 3 of the custom-output-dir-entry input schema - used for vcf_tarball, compressed_metrics_tarball and compressed_reporting_tarball inputs
+      - var get_custom_output_dir_entry_from_tarball = function(tarball_obj, files_list_str, collection_name, copy_method){
+          /*
+          Create the schema object with the tarball, list of files, and the collection name and copy method
+          */
+          return {
+            "collection_name":collection_name,
+            "copy_method":copy_method,
+            "files_list_str":files_list_str,
+            "tarball":tarball_obj
+          };
+        }
+      # Actual script to collect files
+      - var get_custom_output_dir_entry_list = function(inputs){
+          /*
+          Get the entry list by first initialising with the results directory,
+          Then collect the sample post processing pipeline subdirectories
+          */
+          var tso500_entry_list = [
+                get_custom_output_dir_entry_from_directory_and_file_str_list(inputs.results_dir,
+                                                                             [
+                                                                               "MetricsOutput.tsv",
+                                                                               "dsdm.json"
+                                                                             ],
+                                                                             null,
+                                                                             "top_dir")
+              ];
+
+          /*
+          Iterate through sample output directories
+          */
+          for (var sample_dir_iter=0; sample_dir_iter < inputs.per_sample_post_processing_output_dirs.length; sample_dir_iter++){
+            /*
+            Easier to initialise the sample subdirectory object
+            */
+            var sample_dir = inputs.per_sample_post_processing_output_dirs[sample_dir_iter];
+
+            /*
+            Append the list of directories
+            */
+            tso500_entry_list.push(get_custom_output_dir_entry_from_directory_and_file_str_list(sample_dir, null, sample_dir.basename, "sub_dir"));
+          }
+
+          /*
+          Return the dir entry list
+          */
+          return tso500_entry_list;
+        }
+
+inputs:
+  # The results directory and the array of directories for each of the samples
+  per_sample_post_processing_output_dirs:
+    label: per sample post processing output dirs
+    doc: |
+      The per sample post processing output directories
+    type: Directory[]
+  results_dir:
+    label: results dir
+    doc: |
+      The results directory from the tso500 workflow
+    type: Directory
+
+
+outputs:
+  tso500_output_dir_entry_list:
+    label: tso500 output dir entry list
+    doc: |
+      The list of custom output dir entry schemas to use as input to custom-dir-entry list
+    type: ../../../schemas/custom-output-dir-entry/2.0.0/custom-output-dir-entry__2.0.0.yaml#custom-output-dir-entry[]
+
+expression: >-
+  ${
+    return {
+            "tso500_output_dir_entry_list": get_custom_output_dir_entry_list(inputs)
+           };
+   }

--- a/expressions/get-file-from-directory/1.0.0/get-file-from-directory__1.0.0.cwl
+++ b/expressions/get-file-from-directory/1.0.0/get-file-from-directory__1.0.0.cwl
@@ -1,0 +1,81 @@
+cwlVersion: v1.1
+class: ExpressionTool
+
+# Extensions
+$namespaces:
+    s: https://schema.org/
+    ilmn-tes: http://platform.illumina.com/rdf/ica/
+$schemas:
+  - https://schema.org/version/latest/schemaorg-current-http.rdf
+
+# Metadata
+s:author:
+    class: s:Person
+    s:name: Alexis Lucattini
+    s:email: Alexis.Lucattini@umccr.org
+    s:identifier: https://orcid.org/0000-0001-9754-647X
+
+# ID/Docs
+id: get-file-from-directory--1.0.0
+label: get-file-from-directory v(1.0.0)
+doc: |
+    Collect a file from a directory
+
+requirements:
+  LoadListingRequirement:
+    loadListing: shallow_listing
+  InlineJavascriptRequirement:
+    expressionLib:
+      - var get_file_obj_from_directory = function(input_dir, file_basename){
+          /*
+          Iterate through listing of input directory
+          Get the file object that basename attribute matches file_basename input param
+          */
+
+          /*
+          Initialise output object
+          */
+          var output_file_obj = null;
+
+          /*
+          Iterate through listing
+          */
+          for (var input_dir_iter=0; input_dir_iter < input_dir.listing.length; input_dir_iter++){
+            /*
+            Check match, append and break if match exists
+            */
+            if (input_dir.listing[input_dir_iter].basename === file_basename){
+              /*
+              This is a match, append to outputs
+              */
+              output_file_obj = input_dir.listing[input_dir_iter];
+              break;
+            }
+          }
+
+          return output_file_obj;
+        }
+
+inputs:
+  input_dir:
+    label: input dir
+    doc: |
+      Input directory with the file present
+    type: Directory
+  file_basename:
+    label: file basename
+    doc: |
+      The basename of the file we wish to extract from the directory
+    type: string
+
+outputs:
+  output_file:
+    label: output file
+    doc: |
+      File extracted from the directory
+    type: File
+
+expression: >-
+  ${
+    return {"output_file": get_file_obj_from_directory(inputs.input_dir, inputs.file_basename)};
+  }

--- a/expressions/get-files-from-directory/1.0.0/get-files-from-directory__1.0.0.cwl
+++ b/expressions/get-files-from-directory/1.0.0/get-files-from-directory__1.0.0.cwl
@@ -68,7 +68,7 @@ inputs:
   input_dir:
     label: input dir
     doc: |
-      Input directory with the bam file present
+      Input directory with the file present
     type: Directory
   file_basename_list:
     label: file basename list

--- a/expressions/get-subdirectory-from-directory/1.0.0/get-subdirectory-from-directory__1.0.0.cwl
+++ b/expressions/get-subdirectory-from-directory/1.0.0/get-subdirectory-from-directory__1.0.0.cwl
@@ -1,0 +1,81 @@
+cwlVersion: v1.1
+class: ExpressionTool
+
+# Extensions
+$namespaces:
+    s: https://schema.org/
+    ilmn-tes: http://platform.illumina.com/rdf/ica/
+$schemas:
+  - https://schema.org/version/latest/schemaorg-current-http.rdf
+
+# Metadata
+s:author:
+    class: s:Person
+    s:name: Alexis Lucattini
+    s:email: Alexis.Lucattini@umccr.org
+    s:identifier: https://orcid.org/0000-0001-9754-647X
+
+# ID/Docs
+id: get-subdirectory-from-directory--1.0.0
+label: get-subdirectory-from-directory v(1.0.0)
+doc: |
+    Collect a subdirectory (and contents) from a directory
+
+requirements:
+  LoadListingRequirement:
+    loadListing: deep_listing
+  InlineJavascriptRequirement:
+    expressionLib:
+      - var get_sub_dir_obj_from_directory = function(input_dir, directory_basename){
+          /*
+          Iterate through listing of input directory
+          Get the directory object that basename attribute matches
+          */
+
+          /*
+          Initialise output object
+          */
+          var output_dir_obj = null;
+
+          /*
+          Iterate through listing
+          */
+          for (var input_dir_iter=0; input_dir_iter < input_dir.listing.length; input_dir_iter++){
+            /*
+            Check match, append and break if match exists
+            */
+            if (input_dir.listing[input_dir_iter].basename === directory_basename){
+              /*
+              This is a match, append to outputs
+              */
+              output_dir_obj = input_dir.listing[input_dir_iter];
+              break;
+            }
+          }
+
+          return output_dir_obj;
+        }
+
+inputs:
+  input_dir:
+    label: input dir
+    doc: |
+      Input directory with the directory present
+    type: Directory
+  sub_directory_basename:
+    label: sub-directory basename
+    doc: |
+      The name of the sub directory
+    type: string
+
+outputs:
+  output_directory:
+    label: output directory
+    doc: |
+      Output directory extracted from directory
+    type: Directory
+
+expression: >-
+  ${
+    return {"output_directory": get_sub_dir_obj_from_directory(inputs.input_dir, inputs.sub_directory_basename)};
+  }

--- a/expressions/parse-string-array/1.0.0/parse-string-array__1.0.0.cwl
+++ b/expressions/parse-string-array/1.0.0/parse-string-array__1.0.0.cwl
@@ -1,0 +1,41 @@
+cwlVersion: v1.1
+class: ExpressionTool
+
+# Extensions
+$namespaces:
+    s: https://schema.org/
+    ilmn-tes: http://platform.illumina.com/rdf/ica/
+$schemas:
+  - https://schema.org/version/latest/schemaorg-current-http.rdf
+
+# Metadata
+s:author:
+    class: s:Person
+    s:name: Alexis Lucattini
+    s:email: Alexis.Lucattini@umccr.org
+    s:identifier: https://orcid.org/0000-0001-9754-647X
+
+# ID/Docs
+id: parse-string-array--1.0.0
+label: parse-string-array v(1.0.0)
+doc: |
+    Parse an array of strings. Useful in situations where the source needs to be a string, but the file needs to come from the valueFrom expression.
+
+inputs:
+  input_string_array:
+    label: string_array
+    doc: |
+      An array of stringegers
+    type: string[]
+
+outputs:
+  output_string_array:
+    label: output string array
+    doc: |
+      Output array of stringegers (identical to the input)
+    type: string[]
+
+expression: >-
+  ${
+    return {"output_string_array": inputs.input_string_array};
+  }

--- a/expressions/parse-string/1.0.0/parse-string__1.0.0.cwl
+++ b/expressions/parse-string/1.0.0/parse-string__1.0.0.cwl
@@ -1,0 +1,44 @@
+cwlVersion: v1.1
+class: ExpressionTool
+
+# Extensions
+$namespaces:
+    s: https://schema.org/
+    ilmn-tes: http://platform.illumina.com/rdf/ica/
+$schemas:
+  - https://schema.org/version/latest/schemaorg-current-http.rdf
+
+# Metadata
+s:author:
+    class: s:Person
+    s:name: Alexis Lucattini
+    s:email: Alexis.Lucattini@umccr.org
+    s:identifier: https://orcid.org/0000-0001-9754-647X
+
+requirements:
+  InlineJavascriptRequirement: {}
+
+# ID/Docs
+id: parse-string--1.0.0
+label: parse-string v(1.0.0)
+doc: |
+    Parse an string. Useful in situations where the source needs to be a string, but the file needs to come from the valueFrom expression.
+
+inputs:
+  input_string:
+    label: input string
+    doc: |
+      The input stringeger
+    type: string
+
+outputs:
+  output_string:
+    label: output string
+    doc: |
+      The same as the input stringeger
+    type: string
+
+expression: >-
+  ${
+    return {"output_string": inputs.input_string};
+  }

--- a/tools/custom-create-directory/2.0.0/custom-create-directory__2.0.0.cwl
+++ b/tools/custom-create-directory/2.0.0/custom-create-directory__2.0.0.cwl
@@ -76,7 +76,7 @@ requirements:
             We use the listing object but this will exist only when this function is called in the inputBinding
             */
             listing_obj = [
-                            {"entryname":key_name}
+                            {"entryname":schema_object[key_name]}
                           ];
 
           } else if (schema_object[key_name].hasOwnProperty("class") && (schema_object[key_name].class === "File" || schema_object[key_name].class === "Directory")) {

--- a/tools/custom-tso500-make-exon-coverage-qc/1.0.0/custom-tso500-make-exon-coverage-qc__1.0.0.cwl
+++ b/tools/custom-tso500-make-exon-coverage-qc/1.0.0/custom-tso500-make-exon-coverage-qc__1.0.0.cwl
@@ -105,10 +105,10 @@ requirements:
                 coverage_df['length'] = coverage_df.apply(lambda x: x['end'] - x['start'], axis='columns')
 
                 # Get Percentage of region in '100'
-                coverage_df['pct_100X'] = coverage_df.apply(lambda x: (100.0 * x['100X']) / x['length'], axis='columns')
+                coverage_df['pct_100X'] = coverage_df.apply(lambda x: round((100.0 * x['100X']) / x['length'], 1), axis='columns')
 
                 # Filter out regions where pct_100X > 50
-                coverage_df.query("pct_100X <= 50")
+                coverage_df.query("pct_100X <= 50", inplace=True)
 
                 # Get name from bed region
                 coverage_df['region_name_len'] = coverage_df['region'].apply(lambda x: len(x.split("_")))
@@ -123,7 +123,7 @@ requirements:
                 coverage_df.query("transcript_id.str.startswith('NM')", inplace=True)
 
                 # Get 250X as a percentage
-                coverage_df["pct_250X"] = coverage_df.apply(lambda x: (100.0 * x['250X']) / x['length'], axis='columns')
+                coverage_df["pct_250X"] = coverage_df.apply(lambda x: round((100.0 * x['250X']) / x['length'], 1), axis='columns')
 
                 # Strip Exon or Intron from the start of the ID
                 coverage_df["exon_id"] = coverage_df["exon_id"].apply(lambda x: re.sub("^(Exon|Intron)", "", x))

--- a/workflows/tso500-ctdna-post-processing-pipeline/1.0.0/tso500-ctdna-post-processing-pipeline__1.0.0.cwl
+++ b/workflows/tso500-ctdna-post-processing-pipeline/1.0.0/tso500-ctdna-post-processing-pipeline__1.0.0.cwl
@@ -619,11 +619,11 @@ steps:
           ${
             return self.align_collapse_fusion_caller_dir;
           }
-      stiched_realigned_dir:
+      variant_caller_dir:
         source: tso500_outputs_by_sample
         valueFrom: |
           ${
-            return self.stitched_realigned_dir;
+            return self.variant_caller_dir;
           }
       merged_annotation_dir:
         source: tso500_outputs_by_sample

--- a/workflows/tso500-ctdna-post-processing-pipeline/1.0.0/tso500-ctdna-post-processing-pipeline__1.0.0.cwl
+++ b/workflows/tso500-ctdna-post-processing-pipeline/1.0.0/tso500-ctdna-post-processing-pipeline__1.0.0.cwl
@@ -371,7 +371,7 @@ steps:
       Compress the tmb, msi and sample analysis results jsons with gzip
     scatter: uncompressed_file
     # bgzip needs drastically less than usual given how small these files are!
-    hints:
+    requirements:
       ResourceRequirement:
         ilmn-tes:resources:
           tier: standard
@@ -397,7 +397,7 @@ steps:
       Zip up the compressed jsons into a tar ball.
       This is to limit the number of input files / directories into the final collection step.
     # tar needs drastically less than usual given how small these files are!
-    hints:
+    requirements:
       ResourceRequirement:
         ilmn-tes:resources:
           tier: standard
@@ -506,7 +506,7 @@ steps:
       Gather the compressed metric jsons files into a tar ball.
       This is to limit the number of input files / directories into the final collection step.
     # gzip needs drastically less than usual given how small these files are!
-    hints:
+    requirements:
       ResourceRequirement:
         ilmn-tes:resources:
           tier: standard
@@ -540,7 +540,7 @@ steps:
       Compress (and index) vcf files with bgzip
     scatter: uncompressed_vcf_file
     # bgzip needs drastically less than usual given how small these files are!
-    hints:
+    requirements:
       ResourceRequirement:
         ilmn-tes:resources:
           tier: standard
@@ -574,7 +574,7 @@ steps:
       Gather the vcf files into a tar ball.
       This is to limit the number of input files / directories into the final collection step.
     # tar needs drastically less than usual given how small these files are!
-    hints:
+    requirements:
       ResourceRequirement:
         ilmn-tes:resources:
           tier: standard

--- a/workflows/tso500-ctdna-with-post-processing-pipeline/1.1.0--1.0.0/tso500-ctdna-with-post-processing-pipeline__1.1.0--1.0.0.cwl
+++ b/workflows/tso500-ctdna-with-post-processing-pipeline/1.1.0--1.0.0/tso500-ctdna-with-post-processing-pipeline__1.1.0--1.0.0.cwl
@@ -1,0 +1,190 @@
+cwlVersion: v1.1
+class: Workflow
+
+# Extensions
+$namespaces:
+    s: https://schema.org/
+$schemas:
+  - https://schema.org/version/latest/schemaorg-current-http.rdf
+
+# Metadata
+s:author:
+    class: s:Person
+    s:name: Alexis Lucattini
+    s:email: Alexis.Lucattini@umccr.org
+    s:identifier: https://orcid.org/0000-0001-9754-647X
+
+# ID/Docs
+id: tso500-ctdna-with-post-processing-pipeline--1.1.0--1.0.0
+label: tso500-ctdna-with-post-processing-pipeline v(1.1.0--1.0.0)
+doc: |
+    Runs the tso500-ctdna pipeline then runs the post-processing pipeline over each sample
+    Only intermediate step is collecting the tso500 bed file from the resources directory
+
+requirements:
+    InlineJavascriptRequirement: {}
+    ScatterFeatureRequirement: {}
+    MultipleInputFeatureRequirement: {}
+    StepInputExpressionRequirement: {}
+    SubworkflowFeatureRequirement: {}
+    SchemaDefRequirement:
+      types:
+        - $import: ../../../schemas/tso500-sample/1.0.0/tso500-sample__1.0.0.yaml
+        - $import: ../../../schemas/fastq-list-row/1.0.0/fastq-list-row__1.0.0.yaml
+        - $import: ../../../schemas/tso500-outputs-by-sample/1.0.0/tso500-outputs-by-sample__1.0.0.yaml
+
+inputs:
+  # All of the inputs to the standadrd tso500 ctdna post processing pipeline
+  tso500_samples:
+    label: tso500 samples
+    doc: |
+      A list of tso500 samples each element has the following attributes:
+      * sample_id
+      * sample_type
+      * pair_id
+    type: ../../../schemas/tso500-sample/1.0.0/tso500-sample__1.0.0.yaml#tso500-sample[]
+  fastq_list_rows:
+    label: fastq list rows
+    doc: |
+      A list of fastq list rows where each element has the following attributes
+      * rgid  # Not used
+      * rgsm
+      * rglb  # Not used
+      * read_1
+      * read_2
+    type: ../../../schemas/fastq-list-row/1.0.0/fastq-list-row__1.0.0.yaml#fastq-list-row[]
+  samplesheet:
+    # No input binding required, samplesheet is placed in input.json
+    label: sample sheet
+    doc: |
+      The sample sheet file, expects a V2 samplesheet.
+      Even though we don't demultiplex, we still need the information on Sample_Type and Pair_ID to determine which
+      workflow (DNA / RNA) to run through, we gather this through the tso500_samples input schema and then append to the
+      samplesheet. Please make sure that the sample_id in the tso500 sample schema match the Sample_ID in the
+      "<samplesheet_prefix>_Data" column.
+    type: File
+  samplesheet_prefix:
+    label: samplesheet prefix
+    doc: |
+      Points to the TSO500 section of the samplesheet.  If you are using a samplesheet from BCLConvert,
+      please set this to "BCLConvert"
+    type: string?
+    default: "TSO500L"
+  # Run Info file
+  run_info_xml:
+    # Bound in listing expression
+    label: run info xml
+    doc: |
+      The run info xml file found inside the run folder
+    type: File
+  # Run Parameters File
+  run_parameters_xml:
+    # Bound in listing expression
+    label: run parameters xml
+    doc: |
+      The run parameters xml file found inside the run folder
+    type: File
+  # Reference inputs
+  resources_dir:
+    # No input binding required, directory path is placed in input.json
+    label: resources dir
+    doc: |
+      The directory of resources
+    type: Directory
+  dragen_license_key:
+    label: dragen license key
+    doc: |
+      File containing the dragen license
+    type: File?
+
+
+steps:
+  ####################
+  # Intermediate steps
+  ####################
+  get_tso_manifest_bed_from_resources_dir:
+    label: get tso bed file from resources dir
+    doc: |
+      Given the resources directory collect the following file:
+        * TST500C_manifest.bed
+    in:
+      input_dir:
+        source: resources_dir
+      file_basename_list:
+        valueFrom: |
+          ${
+            return [
+                     "TST500C_manifest.bed";
+                   ];
+          }
+    out:
+      - id: output_files
+    run: ../../../expressions/get-files-from-directory/1.0.0/get-files-from-directory__1.0.0.cwl
+  parse_tso_manifest_file:
+    label: parse tso manifest file
+    doc: |
+      Scatter used below, easier to parse file in here than use a valueFrom expression from within the scatter
+    in:
+      input_file:
+        source: get_tso_manifest_bed_from_resources_dir/output_files
+        valueFrom: |
+          ${
+            return self[0]
+          }
+    out:
+      - id: output_file
+    run: ../../../expressions/parse-file/1.0.0/parse-file__1.0.0.cwl
+
+  ############################
+  # Run the tso ctdna pipeline
+  ############################
+  run_tso_ctdna_workflow_step:
+    label: run tso ctdna workflow step
+    doc: |
+      Run the CWL version of the tso500 ctDNA WDL / ISL workflow
+    in:
+      tso500_samples:
+        source: tso500_samples
+      fastq_list_rows:
+        source: fastq_list_rows
+      samplesheet:
+        source: samplesheet
+      samplesheet_prefix:
+        source: samplesheet_prefix
+      run_info_xml:
+        source: run_info_xml
+      run_parameters_xml:
+        source: run_parameters_xml
+      resources_dir:
+        source: resources_dir
+      dragen_license_key:
+        source: dragen_license_key
+    out:
+      - outputs_by_sample
+    run: ../../../workflows/tso500-ctdna/1.1.0--120/tso500-ctdna__1.1.0--120.cwl
+
+  ############################################
+  # Run the tso ctdna post processing pipeline
+  ############################################
+  run_tso_ctdna_post_processing_workflow_step:
+    label: run tso ctdna post processing workflow step
+    doc: |
+      Run the very customised ctdna post processing workflow step for each sample
+    # Scatter over each sample
+    scatter: tso500_outputs_by_sample
+    in:
+      tso500_outputs_by_sample:
+        source: run_tso_ctdna_workflow_step/outputs_by_sample
+      tso_manifest_bed:
+        source: parse_tso_manifest_file/output_file
+    out:
+      - id: post_processing_output_directory
+    run: ../../../workflows/tso500-ctdna-post-processing-pipeline/1.0.0/tso500-ctdna-post-processing-pipeline__1.0.0.cwl
+
+outputs:
+  post_processing_output_dirs_by_sample:
+    label: post processing output dirs by sample
+    doc: |
+      Each of the post processing output directories for each sample in the workflow
+    type: Directory[]
+    outputSource: run_tso_ctdna_post_processing_workflow_step/post_processing_output_directory


### PR DESCRIPTION
Added in the coupling workflow -> That is the glue between the [cwl tso500 ctDNA pipeline](https://github.com/umccr/cwl-ica/blob/main/workflows/tso500-ctdna/1.1.0--120/tso500-ctdna__1.1.0--120.cwl) and the [cwl tso500 ctDNA post processing pipeline](https://github.com/umccr/cwl-ica/blob/main/workflows/tso500-ctdna-post-processing-pipeline/1.0.0/tso500-ctdna-post-processing-pipeline__1.0.0.cwl)

## Changelog by commit ID

### 5ded20490bb393e5ffd7a91e6770e601d7858490

First commit of the coupling workflow:

#### Step descriptions

##### Pre ctDNA TSO500 workflow steps
  * get_tso_manifest_bed_from_resources_dir -> Need bed file for post processing workflow, user only puts in `resources` directory as an input into the workflow though.  
  * parse_tso_manifest_file -> Way to break down an array of files to a single file.
  
##### ctDNA TSO500 workflow step
  * Call the ctDNA TSO500 workflow step
  
##### Post processing step
  * No steps in between the workflow and the post processing step 
  * This one is scattered out for each sample in the workflow 

### 08d1a97c4a477ca6ac16f3e7439e27caeb29ce3b

Appended creation of the final directory structure to the workflow

#### Bug updates
* Stitched bam should be cleaned.stitched.bam and from the variant caller directory not the stitched realigned directory

#### Step updates

##### Pre step to create final directory step:
* Pre-step in the full coupling workflow to create the final output directory step

##### Create final directory step:
* Create a final output directory containing the metrics output tsv file, the dsdm json file along with the sample post-processing directories


### 315647de1b970c7f9b1c2cb33c71010ecb7ba07a

#### Bug updates
* Small bug fix to fix up the input parsers for the custom-output-directory tool

### 6695ac5e7ec747cd1446375b523e10c45bfac6de

#### Bug updates
* Moved from hints to requirements for within steps to overcome https://github.com/common-workflow-language/cwltool/issues/1484

### 67b4a0e61d3ebe89434f08a4432952fe20203726

* Added expression 'get-file-from-directory' (single version of get-files-from-directory)
* Use 'get-file-from-directory' single rather than array based 'get-files-from-directory'

* Added expression to get a subdirectory from a directory (with deep listing)
* Added expression to 'get a string attribute from the tso50 sample object'
* Added step to get the sample output directory as an output to the full workflow

* Added 'parse-string' expressions as extra goodies

### a2939da40749c3278c109154472750419a5374ab

* Added seraseq run to tso500 ctdna pipeline

### 03d9cf8daa02972589d4bdf224960d71dc46b993

* Added workflow to production