### PR TITLE
Given PR approval happens on branch, checkout branch, not merge ref

### DIFF
--- a/.github/workflows/sync-tools_and_sync-workflows.yml
+++ b/.github/workflows/sync-tools_and_sync-workflows.yml
@@ -117,7 +117,7 @@ jobs:
         id: git_push
         run: |
           # Pull first
-          git pull --rebase origin "${GITHUB_REF}"
+          git pull --rebase origin "${GITHUB_HEAD_REF}"
 
           # Push after
-          git push origin "${GITHUB_REF}"
+          git push origin "${GITHUB_HEAD_REF}"

--- a/.github/workflows/update_auto_completion.yml
+++ b/.github/workflows/update_auto_completion.yml
@@ -50,7 +50,7 @@ jobs:
         id: git_push
         run: |
           # Pull first
-          git pull --rebase origin "${GITHUB_REF}"
+          git pull --rebase origin "${GITHUB_HEAD_REF}"
 
           # Push after
-          git push origin "${GITHUB_REF}"
+          git push origin "${GITHUB_HEAD_REF}"


### PR DESCRIPTION
GITHUB_REF references to PR rather than branch,
use GITHUB_HEAD_REF to rebase / push to branch