### PR TITLE
Sync update to cater for auto-changing ts on ICA

### DIFF
--- a/src/cwl-ica-conda-env.yaml
+++ b/src/cwl-ica-conda-env.yaml
@@ -25,3 +25,4 @@ dependencies:
     - PyJWT
     - tabulate
     - mdutils
+    - deepdiff

--- a/src/utils/miscell.py
+++ b/src/utils/miscell.py
@@ -19,6 +19,8 @@ from utils.repo import get_tenant_yaml_path, get_cwl_ica_repo_path
 import os
 from base64 import b64encode, b64decode
 import zlib
+from deepdiff import DeepDiff
+import json
 
 logger = get_logger()
 
@@ -359,3 +361,17 @@ def cwl_id_to_path(cwl_id: str) -> Path:
     :return:
     """
     return Path(cwl_id.rsplit("#", 1)[-1])
+
+
+def summarise_differences_of_two_dicts(dict_1: Dict, dict_2: Dict) -> str:
+    """
+    Summarise the difference of two dicts with deepdiff
+    Credit: https://stackoverflow.com/a/50912266/6946787
+    :param dict_1:
+    :param dict_2:
+    :return:
+    """
+
+    diff = DeepDiff(dict_1, dict_2)
+
+    return json.dumps(json.loads(diff.to_json()), indent=4)


### PR DESCRIPTION
## Additions:  
  * Added function to compare two dicts
  * Added typing to compare_item_version_and_ica_workflow_version function
  * Add warning showing differences when workflow has been edited.  
  * Install deepdiff in conda env

## Updates:
  * Remove warning about cannot update workflow when --force is used