### PR TITLE
Force downgrade of setuptools for conda env installation

### DIFF
--- a/src/cwl-ica-conda-env.yaml
+++ b/src/cwl-ica-conda-env.yaml
@@ -8,6 +8,9 @@ dependencies:
   - pip
   - python=3.8
   - pip:
+    # Force downgrade of setuptools as shown
+    # https://stackoverflow.com/questions/69100275/error-while-downloading-the-requirements-using-pip-install-setup-command-use-2
+    - setuptools<58
     - cwlref-runner
     - cwltool==3.0.20201203173111  # Matches ICA current version
     - cwl_utils
@@ -26,6 +29,3 @@ dependencies:
     - tabulate
     - mdutils
     - deepdiff
-    # Force downgrade of setuptools as shown
-    # https://stackoverflow.com/questions/69100275/error-while-downloading-the-requirements-using-pip-install-setup-command-use-2
-    - setuptools<58

--- a/src/cwl-ica-conda-env.yaml
+++ b/src/cwl-ica-conda-env.yaml
@@ -26,3 +26,6 @@ dependencies:
     - tabulate
     - mdutils
     - deepdiff
+    # Force downgrade of setuptools as shown
+    # https://stackoverflow.com/questions/69100275/error-while-downloading-the-requirements-using-pip-install-setup-command-use-2
+    - setuptools<58


### PR DESCRIPTION
Forcing downgrade of setuptools as seen in https://stackoverflow.com/questions/69100275/error-while-downloading-the-requirements-using-pip-install-setup-command-use-2 