### PR TITLE
Added parameter `--ignore-workflow-id-mismatch` to create-x-submission-template.  

### DIFF
--- a/src/subcommands/query/create_submission_template.py
+++ b/src/subcommands/query/create_submission_template.py
@@ -83,6 +83,7 @@ class CreateSubmissionTemplate(Command):
         self.ica_workflow_id = None  # type: Optional[str]
         self.ica_workflow_version_name = None  # type: Optional[str]
         self.ica_workflow_run_id = None  # type: Optional[str]
+        self.ignore_workflow_id_mismatch = False  # type: bool
 
         # Check help
         self.check_length(command_argv)
@@ -199,6 +200,10 @@ class CreateSubmissionTemplate(Command):
         # Check if instance exists
         if self.args.get("--ica-workflow-run-instance-id", None) is not None:
             self.ica_workflow_run_id = self.args.get("--ica-workflow-run-instance-id")
+
+        # Check ignore workflow id mismatch
+        if self.args.get("--ignore-workflow-id-mismatch", False):
+            self.ignore_workflow_id_mismatch = True
 
         # Load cwl
         items: List[Dict] = self.get_item_list()
@@ -482,11 +487,11 @@ class CreateSubmissionTemplate(Command):
                                               allow_unsuccessful_run=True)
 
         # Cross reference
-        if not self.ica_workflow_id == ica_workflow_run_obj.ica_workflow_id:
+        if not self.ica_workflow_id == ica_workflow_run_obj.ica_workflow_id and not self.ignore_workflow_id_mismatch:
             logger.error(f"Cannot use {self.ica_workflow_run_id} as a reference. ICA workflow ids do not match")
             logger.error(f"Apples: {self.ica_workflow_id} vs Oranges: {ica_workflow_run_obj.ica_workflow_id}")
             raise ValueError
-        if not self.ica_workflow_version_name == ica_workflow_run_obj.ica_workflow_version_name:
+        if not self.ica_workflow_version_name == ica_workflow_run_obj.ica_workflow_version_name and not self.ignore_workflow_id_mismatch:
             logger.warning(f"Got version name {self.ica_workflow_version_name}, "
                            f"but workflow run id is from version {ica_workflow_run_obj.ica_workflow_version_name}")
 

--- a/src/subcommands/query/create_tool_submission_template.py
+++ b/src/subcommands/query/create_tool_submission_template.py
@@ -22,6 +22,7 @@ class CreateToolSubmissionTemplate(CreateSubmissionTemplate):
                                                       (--project=<project_tool_belongs_to>)
                                                       [--launch-project=<project_to_launch_tool>]
                                                       [--ica-workflow-run-instance-id=<ica_workflow_run_id>]
+                                                      [--ignore-workflow-id-mismatch]
                                                       [--access-token=<access_token>]
                                                       [--curl]
 
@@ -34,6 +35,7 @@ Options:
     --launch-project=<project>                                 Optional: Linked project to launch from
     --ica-workflow-run-instance-id=<workflow_run_instance_id>  Optional: Workflow run id to base yaml template from
     --access-token=<access-token>                              Optional: Access token in same project as run instance id, ideally use env var ICA_ACCESS_TOKEN
+    --ignore-workflow-id-mismatch                              Optional: Ignore workflow id mismatch, useful for when creating a template for a different context
     --prefix=<prefix>                                          Optional: prefix to the run name and the output files
     --curl                                                     Optional: Use the curl command over ica binary to launch tool
 

--- a/src/subcommands/query/create_workflow_submission_template.py
+++ b/src/subcommands/query/create_workflow_submission_template.py
@@ -22,6 +22,7 @@ class CreateWorkflowSubmissionTemplate(CreateSubmissionTemplate):
                                                           (--project=<project_workflow_belongs_to>)
                                                           [--launch-project=<project_to_launch_workflow>]
                                                           [--ica-workflow-run-instance-id=<ica_workflow_run_id>]
+                                                          [--ignore-workflow-id-mismatch]
                                                           [--access-token=<access_token>]
                                                           [--curl]
 
@@ -34,6 +35,7 @@ Options:
     --launch-project<project>                                  Optional: Linked project to launch from
     --ica-workflow-run-instance-id=<workflow_run_instance_id>  Optional: Workflow run id to base yaml template from
     --access-token=<access-token>                              Optional: Access token in same project as run instance id, ideally use env var ICA_ACCESS_TOKEN
+    --ignore-workflow-id-mismatch                              Optional: Ignore workflow id mismatch, useful for when creating a template for a different context
     --prefix=<prefix>                                          Optional: prefix to the run name and the output files
     --curl                                                     Optional: Use the curl command over ica binary to launch workflow
 


### PR DESCRIPTION
Useful for when copying inputs from different projects.  
