### PR TITLE
Updated id attribute for steps in subworkflows.

### DIFF
--- a/src/subcommands/query/get_workflow_step_ids.py
+++ b/src/subcommands/query/get_workflow_step_ids.py
@@ -140,7 +140,7 @@ Example:
                 step_cwl_obj = step_cwl_wf_obj.cwl_obj
 
                 step_ids.extend(self.get_steps_of_cwl_workflow(step_run_path, step_cwl_obj,
-                                                               path_prefix=Path(path_prefix) / Path(cwl_id_to_path(step.id).name)))
+                                                               path_prefix=Path(path_prefix) / Path(step.run).name))
             else:
                 step_ids.append(path_prefix / cwl_id_to_path(step.id).name)
 


### PR DESCRIPTION
Not step_id/subwf_step_id but instead - subwf_file_name/subwf_step_id which seems silly

i.e from `'run_tso_ctdna_workflow_step/run_tso500_ctdna_analysis_workflow_step'` to `tso500-ctdna__1.1.0--120.cwl/run_tso500_ctdna_analysis_workflow_step`. No idea how this is called manually or if the same subworkflow is called twice