### PR TITLE
GHIF-QC workflow

### DIFF
--- a/config/project.yaml
+++ b/config/project.yaml
@@ -317,6 +317,16 @@ projects:
             modification_time: 2021-12-15T23:15:41UTC
             run_instances:
               - wfr.dce6425b60044757a78bb545c627c58a
+      - name: samtools-stats
+        path: samtools-stats
+        ica_workflow_name: samtools-stats_dev-wf
+        ica_workflow_id: wfl.620ed24f36114e548ba60fe142712eb7
+        versions:
+          - name: 1.13.0
+            path: 1.13.0/samtools-stats__1.13.0.cwl
+            ica_workflow_version_name: 1.13.0
+            modification_time: 2021-12-17T04:04:55UTC
+            run_instances: []
     workflows:
       - name: optitype-pipeline
         path: optitype-pipeline

--- a/config/project.yaml
+++ b/config/project.yaml
@@ -342,7 +342,7 @@ projects:
           - name: 1.0.1
             path: 1.0.1/custom-stats-qc__1.0.1.cwl
             ica_workflow_version_name: 1.0.1
-            modification_time: 2022-01-19T01:05:02UTC
+            modification_time: 2022-01-19T02:23:05UTC
             run_instances: []
     workflows:
       - name: optitype-pipeline

--- a/config/project.yaml
+++ b/config/project.yaml
@@ -336,7 +336,7 @@ projects:
           - name: 1.0.0
             path: 1.0.0/custom-stats-qc__1.0.0.cwl
             ica_workflow_version_name: 1.0.0
-            modification_time: 2022-01-11T05:44:28UTC
+            modification_time: 2022-01-13T03:31:35UTC
             run_instances:
               - wfr.eb46716d0e5c487b9f699cd5fbc2821f
     workflows:
@@ -536,7 +536,7 @@ projects:
           - name: 1.0.0
             path: 1.0.0/ghif-qc__1.0.0.cwl
             ica_workflow_version_name: 1.0.0
-            modification_time: 2022-01-12T02:10:29UTC
+            modification_time: 2022-01-13T03:46:01UTC
             run_instances: []
   - project_name: production_workflows
     project_id: fdd48e11-cdcc-46a9-b5ac-dee3a4c5f19d

--- a/config/project.yaml
+++ b/config/project.yaml
@@ -325,7 +325,7 @@ projects:
           - name: 1.13.0
             path: 1.13.0/samtools-stats__1.13.0.cwl
             ica_workflow_version_name: 1.13.0
-            modification_time: 2021-12-17T04:04:55UTC
+            modification_time: 2021-12-21T02:39:12UTC
             run_instances: []
     workflows:
       - name: optitype-pipeline

--- a/config/project.yaml
+++ b/config/project.yaml
@@ -342,7 +342,7 @@ projects:
           - name: 1.0.1
             path: 1.0.1/custom-stats-qc__1.0.1.cwl
             ica_workflow_version_name: 1.0.1
-            modification_time: 2022-01-19T11:19:29UTC
+            modification_time: 2022-01-27T02:21:31UTC
             run_instances: []
       - name: calculate-coverage
         path: calculate-coverage

--- a/config/project.yaml
+++ b/config/project.yaml
@@ -339,6 +339,11 @@ projects:
             modification_time: 2022-01-13T03:31:35UTC
             run_instances:
               - wfr.eb46716d0e5c487b9f699cd5fbc2821f
+          - name: 1.0.1
+            path: 1.0.1/custom-stats-qc__1.0.1.cwl
+            ica_workflow_version_name: 1.0.1
+            modification_time: 2022-01-19T01:05:02UTC
+            run_instances: []
     workflows:
       - name: optitype-pipeline
         path: optitype-pipeline
@@ -541,7 +546,7 @@ projects:
           - name: 1.0.1
             path: 1.0.1/ghif-qc__1.0.1.cwl
             ica_workflow_version_name: 1.0.1
-            modification_time: 2022-01-14T01:06:41UTC
+            modification_time: 2022-01-19T01:07:50UTC
             run_instances: []
   - project_name: production_workflows
     project_id: fdd48e11-cdcc-46a9-b5ac-dee3a4c5f19d

--- a/config/project.yaml
+++ b/config/project.yaml
@@ -528,6 +528,16 @@ projects:
             ica_workflow_version_name: 2.0.0--3.9.3
             modification_time: 2021-12-01T07:47:52UTC
             run_instances: []
+      - name: ghif-qc
+        path: ghif-qc
+        ica_workflow_name: ghif-qc_dev-wf
+        ica_workflow_id: wfl.5d05d214eb3e4604ba7153118173f63e
+        versions:
+          - name: 1.0.0
+            path: 1.0.0/ghif-qc__1.0.0.cwl
+            ica_workflow_version_name: 1.0.0
+            modification_time: 2022-01-12T02:10:29UTC
+            run_instances: []
   - project_name: production_workflows
     project_id: fdd48e11-cdcc-46a9-b5ac-dee3a4c5f19d
     project_description: |

--- a/config/project.yaml
+++ b/config/project.yaml
@@ -557,7 +557,7 @@ projects:
           - name: 1.0.1
             path: 1.0.1/ghif-qc__1.0.1.cwl
             ica_workflow_version_name: 1.0.1
-            modification_time: 2022-01-19T11:19:56UTC
+            modification_time: 2022-01-27T05:15:29UTC
             run_instances:
               - wfr.f6adb13c92e340f89317c337674b18a6
   - project_name: production_workflows

--- a/config/project.yaml
+++ b/config/project.yaml
@@ -560,6 +560,7 @@ projects:
             modification_time: 2022-01-27T05:15:29UTC
             run_instances:
               - wfr.f6adb13c92e340f89317c337674b18a6
+              - wfr.10176db758d94e56833422dfd60d0f90
   - project_name: production_workflows
     project_id: fdd48e11-cdcc-46a9-b5ac-dee3a4c5f19d
     project_description: |

--- a/config/project.yaml
+++ b/config/project.yaml
@@ -547,7 +547,8 @@ projects:
             path: 1.0.1/ghif-qc__1.0.1.cwl
             ica_workflow_version_name: 1.0.1
             modification_time: 2022-01-19T11:19:56UTC
-            run_instances: []
+            run_instances:
+              - wfr.f6adb13c92e340f89317c337674b18a6
   - project_name: production_workflows
     project_id: fdd48e11-cdcc-46a9-b5ac-dee3a4c5f19d
     project_description: |

--- a/config/project.yaml
+++ b/config/project.yaml
@@ -325,7 +325,7 @@ projects:
           - name: 1.13.0
             path: 1.13.0/samtools-stats__1.13.0.cwl
             ica_workflow_version_name: 1.13.0
-            modification_time: 2021-12-21T05:31:47UTC
+            modification_time: 2021-12-21T06:43:57UTC
             run_instances: []
     workflows:
       - name: optitype-pipeline

--- a/config/project.yaml
+++ b/config/project.yaml
@@ -344,6 +344,16 @@ projects:
             ica_workflow_version_name: 1.0.1
             modification_time: 2022-01-19T11:19:29UTC
             run_instances: []
+      - name: calculate-coverage
+        path: calculate-coverage
+        ica_workflow_name: calculate-coverage_dev-wf
+        ica_workflow_id: wfl.de659694e0b04a4f88763674be6a74fe
+        versions:
+          - name: 1.0.0
+            path: 1.0.0/calculate-coverage__1.0.0.cwl
+            ica_workflow_version_name: 1.0.0
+            modification_time: 2022-01-25T02:27:00UTC
+            run_instances: []
     workflows:
       - name: optitype-pipeline
         path: optitype-pipeline

--- a/config/project.yaml
+++ b/config/project.yaml
@@ -335,7 +335,7 @@ projects:
           - name: 1.0.0
             path: 1.0.0/custom-stats-qc__1.0.0.cwl
             ica_workflow_version_name: 1.0.0
-            modification_time: 2022-01-05T01:10:15UTC
+            modification_time: 2022-01-10T02:52:23UTC
             run_instances: []
     workflows:
       - name: optitype-pipeline

--- a/config/project.yaml
+++ b/config/project.yaml
@@ -335,7 +335,7 @@ projects:
           - name: 1.0.0
             path: 1.0.0/custom-stats-qc__1.0.0.cwl
             ica_workflow_version_name: 1.0.0
-            modification_time: 2022-01-04T04:25:54UTC
+            modification_time: 2022-01-05T01:10:15UTC
             run_instances: []
     workflows:
       - name: optitype-pipeline

--- a/config/project.yaml
+++ b/config/project.yaml
@@ -343,7 +343,8 @@ projects:
             path: 1.0.1/custom-stats-qc__1.0.1.cwl
             ica_workflow_version_name: 1.0.1
             modification_time: 2022-01-27T02:21:31UTC
-            run_instances: []
+            run_instances:
+              - wfr.298a81a7fffb4afba83ad0a3e12163ce
       - name: calculate-coverage
         path: calculate-coverage
         ica_workflow_name: calculate-coverage_dev-wf

--- a/config/project.yaml
+++ b/config/project.yaml
@@ -342,7 +342,7 @@ projects:
           - name: 1.0.1
             path: 1.0.1/custom-stats-qc__1.0.1.cwl
             ica_workflow_version_name: 1.0.1
-            modification_time: 2022-01-19T02:23:05UTC
+            modification_time: 2022-01-19T09:25:33UTC
             run_instances: []
     workflows:
       - name: optitype-pipeline
@@ -546,7 +546,7 @@ projects:
           - name: 1.0.1
             path: 1.0.1/ghif-qc__1.0.1.cwl
             ica_workflow_version_name: 1.0.1
-            modification_time: 2022-01-19T01:07:50UTC
+            modification_time: 2022-01-19T09:26:38UTC
             run_instances: []
   - project_name: production_workflows
     project_id: fdd48e11-cdcc-46a9-b5ac-dee3a4c5f19d

--- a/config/project.yaml
+++ b/config/project.yaml
@@ -326,7 +326,8 @@ projects:
             path: 1.13.0/samtools-stats__1.13.0.cwl
             ica_workflow_version_name: 1.13.0
             modification_time: 2021-12-22T04:29:22UTC
-            run_instances: []
+            run_instances:
+              - wfr.32ff48e48bce4d4e8d70efe6fbf92040
       - name: custom-stats-qc
         path: custom-stats-qc
         ica_workflow_name: custom-stats-qc_dev-wf
@@ -335,8 +336,9 @@ projects:
           - name: 1.0.0
             path: 1.0.0/custom-stats-qc__1.0.0.cwl
             ica_workflow_version_name: 1.0.0
-            modification_time: 2022-01-10T02:52:23UTC
-            run_instances: []
+            modification_time: 2022-01-11T05:44:28UTC
+            run_instances:
+              - wfr.eb46716d0e5c487b9f699cd5fbc2821f
     workflows:
       - name: optitype-pipeline
         path: optitype-pipeline

--- a/config/project.yaml
+++ b/config/project.yaml
@@ -342,7 +342,7 @@ projects:
           - name: 1.0.1
             path: 1.0.1/custom-stats-qc__1.0.1.cwl
             ica_workflow_version_name: 1.0.1
-            modification_time: 2022-01-19T09:25:33UTC
+            modification_time: 2022-01-19T11:19:29UTC
             run_instances: []
     workflows:
       - name: optitype-pipeline
@@ -546,7 +546,7 @@ projects:
           - name: 1.0.1
             path: 1.0.1/ghif-qc__1.0.1.cwl
             ica_workflow_version_name: 1.0.1
-            modification_time: 2022-01-19T09:26:38UTC
+            modification_time: 2022-01-19T11:19:56UTC
             run_instances: []
   - project_name: production_workflows
     project_id: fdd48e11-cdcc-46a9-b5ac-dee3a4c5f19d

--- a/config/project.yaml
+++ b/config/project.yaml
@@ -538,6 +538,11 @@ projects:
             ica_workflow_version_name: 1.0.0
             modification_time: 2022-01-13T03:46:01UTC
             run_instances: []
+          - name: 1.0.1
+            path: 1.0.1/ghif-qc__1.0.1.cwl
+            ica_workflow_version_name: 1.0.1
+            modification_time: 2022-01-14T01:06:41UTC
+            run_instances: []
   - project_name: production_workflows
     project_id: fdd48e11-cdcc-46a9-b5ac-dee3a4c5f19d
     project_description: |

--- a/config/project.yaml
+++ b/config/project.yaml
@@ -325,7 +325,7 @@ projects:
           - name: 1.13.0
             path: 1.13.0/samtools-stats__1.13.0.cwl
             ica_workflow_version_name: 1.13.0
-            modification_time: 2021-12-21T06:43:57UTC
+            modification_time: 2021-12-22T04:29:22UTC
             run_instances: []
     workflows:
       - name: optitype-pipeline

--- a/config/project.yaml
+++ b/config/project.yaml
@@ -327,6 +327,16 @@ projects:
             ica_workflow_version_name: 1.13.0
             modification_time: 2021-12-22T04:29:22UTC
             run_instances: []
+      - name: custom-stats-qc
+        path: custom-stats-qc
+        ica_workflow_name: custom-stats-qc_dev-wf
+        ica_workflow_id: wfl.428005f137ab409296a367db1b9f122e
+        versions:
+          - name: 1.0.0
+            path: 1.0.0/custom-stats-qc__1.0.0.cwl
+            ica_workflow_version_name: 1.0.0
+            modification_time: 2022-01-04T04:25:54UTC
+            run_instances: []
     workflows:
       - name: optitype-pipeline
         path: optitype-pipeline

--- a/config/project.yaml
+++ b/config/project.yaml
@@ -325,7 +325,7 @@ projects:
           - name: 1.13.0
             path: 1.13.0/samtools-stats__1.13.0.cwl
             ica_workflow_version_name: 1.13.0
-            modification_time: 2021-12-21T02:39:12UTC
+            modification_time: 2021-12-21T05:31:47UTC
             run_instances: []
     workflows:
       - name: optitype-pipeline

--- a/config/run.yaml
+++ b/config/run.yaml
@@ -1468,3 +1468,34 @@ runs:
         task_stop_time: 1641775863
         task_duration: 2392
         task_metrics: eJyd1MEKwjAMBuBXGTuPkaRJmvkq4kFkBw/FofMgsne33u3A/7YWPprkJzu++/Va5sd6Lkt/6NiVc1YiGbr+sjy/VyPV7zKX2/1VjzTSNnS/lQegWJC3OKa24pYSNUAlYkQ5AUoFqVBDAWWKKCekL3ckryxIhTmQvEIRNe1tSlt5+l8ZCVChUQYmb6xAyiaE9CXIplgSR1QAedVFQSav087/sKkMmoYjm2IeSF457fQl2+kDr/61tw==
+  - ica_workflow_run_instance_id: wfr.f6adb13c92e340f89317c337674b18a6
+    ica_project_launch_context_id: dc8e6ba9-b744-437b-b070-4cf014694b3d
+    ica_workflow_id: wfl.5d05d214eb3e4604ba7153118173f63e
+    ica_workflow_name: ghif-qc_dev-wf
+    ica_workflow_version_name: 1.0.1
+    ica_workflow_run_name: qc-ghif-1.0.1
+    ica_input: eJytj0trAkEQhP+KzDnrGg1EvKng4xIQcm/a3d7ZCfPYTPeYBPG/Z0YCmruHgaGq+LrqrJpwAukjcR9sqxaj6eRppDpjhaLxGjqLuqizyUvWjR+SwBFdls6qscicf2pjLKls29CgmOCLplte1HVyTRMrITdULQpWLZ3qniz5ervbb+Cwrt+Wz9P563xcoJfMCEnKjdyAPDoqqL9IxrCoW+SDg/+X073pDuuSiNQB0+fjWvZ6Nge0AviFkcCH3uK4w2vjSC6cCNo0lDMSE93E/KLFe4PRDZbAtHfL1E3nkGJzXbPdL1fFEIyaBCLp3JkfN+n9ymXYBReAcTDkGTKX3NH+lLVJAgdHPJZvUZfLLwPxuBk=
+    ica_output: eJytkFFPgzAUhf/Kgq+utLS0sDdj4qOJv4CU9sIwQDduyYzL/rsUmc6pDyY+nnNuz+39jpEZ0buuQK89FntTuNHvRl88o+ujzeoYtc5o38wiqi1u4vhQDaSS2paMmzwBLmiV5Zwpw7mSSpQs0zLem3W9bao1I5Sw+L0U42A93ZO5/HYVlRqh1x3M3V+jYA/O+c/o7MLLbH5MmlYjBuehaSEY2LyGxkTmYlJb73fTp43rOtcfWuKGOjaH1jvX3tTQw3C+jp7CW92FBBceCww/r/xnFo93LMlUtvaAnoQNV0B+yi+pXObXbJbx39AwTiWTf4az0LDNUEzXFwiIU1o0NqxA7EmpUsusTisthFCJzUtlrRWK5UJKI3j0vaRyrYVh6ZgEoUyCyCSVkILgQK0qU5rZ3ErQiWE0Or0Bhfva3A==
+    ica_engine_parameters: eJytkT1ywyAQRq/iUeMmkkA4/mvjIik8LpQcAMNKYSKBAosVxeO7B9AkVUqXsG/fzn57zUZjPw7KgkBjp2y/yFrp9mU5NrZo1lyeKRO7CtiKNNsdoxvB2Ga9WZ3plq/LT5G376rJaUEKmj0sMuNx8HgXXTm7XNRiP5zuaHYIQ/J2pr2PMYiSsOdfteCIYIOOVX+J1ICodBtn9OYCERVmmOalXrRDrgW8TgNEog4vya18Vk+D/x+t1XdCjyCV7yMjoeG+C0Cgjkam6vJgRt0ZLpeRUL+l0wWsVRJcYK63GC+4NwdzK9eqAYepnXs0qVWMHRrTxU8W9q1IRWhFQiSM0nR30K3SaSYt6LYgeUAo2dEVrR5J7tBy9C7vuYvJ3H4AkRTCNw==
+    workflow_start_time: 1642591204
+    workflow_end_time: 1642595051
+    workflow_duration: 3847
+    ica_tasks:
+      - ica_task_run_instance_id: trn.5617b7c1159b46a48fe01c5b21983e14
+        task_step_name: samtools_stats_step
+        task_name: samtools-stats__1.13.0.cwl
+        task_cpus: 4
+        task_memory: 14
+        task_start_time: 1642591352
+        task_stop_time: 1642593779
+        task_duration: 2426
+        task_metrics: eJyd000KwjAQBeCrlK6LzH8TryIuRLpwESxaFyK9ewOCK1v07ZLABzNvModXO13KcJ9OZWz3DYeJZ87kXdOex0d9oh3VcxnK9fZ8X+eu+a5CP4p/VUICqeSAYrN1xWuqloioQJRKICoToMw2kl9VTkiFDqURgswrEtJX70iGiTKiogdUTRFRif9XSgZMWRnZFOUAMlRBNkUlIRUqsilqBKlA+nIBfq96AvZLYysNmY8LlJK1og==
+      - ica_task_run_instance_id: trn.867c147977c048f4a67956a6afe281ff
+        task_step_name: custom_stats_qc_step
+        task_name: custom-stats-qc__1.0.1.cwl
+        task_cpus: 0.8
+        task_memory: 3
+        task_start_time: 1642594007
+        task_stop_time: 1642594219
+        task_duration: 211
+        task_metrics: eJyLjgUAARUAuQ==

--- a/config/run.yaml
+++ b/config/run.yaml
@@ -1499,3 +1499,25 @@ runs:
         task_stop_time: 1642594219
         task_duration: 211
         task_metrics: eJyLjgUAARUAuQ==
+  - ica_workflow_run_instance_id: wfr.298a81a7fffb4afba83ad0a3e12163ce
+    ica_project_launch_context_id: dc8e6ba9-b744-437b-b070-4cf014694b3d
+    ica_workflow_id: wfl.428005f137ab409296a367db1b9f122e
+    ica_workflow_name: custom-stats-qc_dev-wf
+    ica_workflow_version_name: 1.0.1
+    ica_workflow_run_name: custom-qc
+    ica_input: eJyNkEFOwzAQRa9SeY1jmhhSd1eigrpBFA4QOY5NjJw4eCYCqerdsZMixK670ejP+09zIn7CccL6A/xQG+v0IHtNtivy3llzrKjyfUNuVr8xkD1676AGlAgxdyLKSUgTeYzXKeq8kmj9MFNa2DIGGCROQEF3wUKXswSnn4rZIUKB/adm+I3kHEFj0MqCXtwWgWsbv0zI1kYUrbjTTdOW3IhSaKVu70vOTZEXgnP28rqvDm97eqzYQgf2vFvnm3JDL9VZqp5douLodG3b1HFJkb89+Cmo+W9Ph90DOf8ACnVyBQ==
+    ica_output: eJy1kMFOwzAMhl9lClfWNm23pLsicecJKjdxuqC0GXWqIaa9O2lhAzEQYhJH+7c+29+B+THsxlA/ku/ZZnFgzisIdi5Yq2mTpnszJHklQXIQxpimBNOALEBnUCDP+bpQmKqRgu+WTyp9A1Labq15uFsq3zXJTL9dsAYIe+hwhn+TT9ngffiSnyJ8npPzuHJANHXurcOpQfZlYufrqozVNoRdvD8SOt/vXeKHNlV7F7x3Ny32OJwezY5x+pOIelpqe9T/ZuS84Tc1l4M/OPq4+Y+yqlKKa2VpO9RRSU1IFNPaTsYYUZ9oXeAaOGqhyxKgkpKLHEAoQIN5xdklxHincXhnxCJpcJWLJtMoClkKoWGlTCZ1FRVLXnDOjq8iSubN
+    ica_engine_parameters: eJytkLtywyAQRX/Fo8ZNLIHI+NXGRVJ4XCj5AAyLhonEEh5WHI//PYAnqdI55XLPPTvspZrQve+0AxHQnavtrOql3zbNpFzdbtZ8TflKKXV85OrI14xLwhnQli6ZgEZEH3BcfIjqYVZhDDaGu1XNzeOzMoz28E9WH8AW54D9/bYkKbKRf3aChwAuqVj7e4UOQtCmz/4RT5BRgfZ8+8yL8YEbAa9nC5no0iS5k8/6yca/0U5/FXQPUscxMxIUj0MCErVHWdL5DiczIJfzTOif6HAC57QEn5jLNZ8V/JuHW5UbrcCHUucxYKmKaQiIQ35kNalb0hLaEkZXjFKaATC9NmUnTWlNFglJDN3QJdksJJxgQFtdvwERdsMa
+    workflow_start_time: 1643250204
+    workflow_end_time: 1643252085
+    workflow_duration: 1881
+    ica_tasks:
+      - ica_task_run_instance_id: trn.daed9a9b9df4434a9473d7e4293a8d88
+        task_step_name: main
+        task_name: main
+        task_cpus: 0.8
+        task_memory: 3
+        task_start_time: 1643250287
+        task_stop_time: 1643250888
+        task_duration: 601
+        task_metrics: eJyLjgUAARUAuQ==

--- a/config/run.yaml
+++ b/config/run.yaml
@@ -1424,3 +1424,47 @@ runs:
         task_stop_time: 1639618343
         task_duration: 1612
         task_metrics: eJyd0rEKwkAMBuBXKZ1LuCS99OKriINIB4fDonUQ6bv3XOREf4duR8hHLj/ZP9v5nMfbfMxTu2vY1I0HCdY17Wm6l1IgL+885sv18eqgsHTNbzX0b1XaPhUjpcpICRlUDmcJJaT6mJBSvFdkrtJItYokUBmcJeRImThK/s8PLSWsFKkhCk4DqlTdxpfqobItylW3KIcXpRSBKmuFDYo54uRtOawjfupq
+  - ica_workflow_run_instance_id: wfr.eb46716d0e5c487b9f699cd5fbc2821f
+    ica_project_launch_context_id: dc8e6ba9-b744-437b-b070-4cf014694b3d
+    ica_workflow_id: wfl.428005f137ab409296a367db1b9f122e
+    ica_workflow_name: custom-stats-qc_dev-wf
+    ica_workflow_version_name: 1.0.0
+    ica_workflow_run_name: custom-qc
+    ica_input: eJxVjLEKwyAURX8lvLmpNEtDti4d+wtBjImC8VnvEwoh/14dOnS7HM49B3GRVGRefbBR75amjhJDUmZjAbp0PwN6F+aAGaIF1TvIBI226FnfTQ1stHiOjW0LJqUgWUtBD+uyhxvU5vzav43ysUah/qtX+QidNVRxCnb2Syu9HrdhvI90fgFhXDz1
+    ica_output: eJx9kM1OwzAQhF+lMldIbOfHTm9cOPIKUby2S5CTDV5HQVR9dxxouSA4WbP7eUY7Z4ZrWtbU+zE4djycWUAY0ohzFuxk6ViWm4+FM3WrRGu5a6DWynS+7TqwjTcgtRS+hJUSTg9vUH4bUrkgpSUiOKL++VFIrXTxStn4/sDMQG4epj2R/cftTERMf3A3xL1/ET/fIAxE++RpvyoPaPzYswRv66xeUlryXYDThPMWCoynEraQEMPdyc0u3grgl0xfC7Jj7HMfPeX8vO1HuwcQzYVXhisjrRag6iq/ng9do0TVNQaUV+y3icdgXbx6ZFE4KbRVptK64bWqNPet5Np2VtTSVdCwyycSoIiX
+    ica_engine_parameters: eJytkLtywyAQRX/Fo8ZNJAHyS27jIik8LpR8AIaVhrEECixWHI//PYAnqdI55bLnnh3uNZuMPe2UBYHGXrLtLOuk25bl1NoCjovVmq4kgaVYbNbHul3VtZDL9ijYhtG2FN6hGfIPkT3NMuNx9Piwqrx7XFTiMB7+yeoQxuTsTfe4LUiSbOCfjeCIYIOqYr8tNICodBf9gzlDRIUZL/fPvGqHXAt4u4wQiSZMklv5op5H/zfaqK+E7kEqP0RGQst9H4BA7Y1M2/nOTLo3XM4joX5WhzNYqyS4wFxvsVZw7w7uUa5VCw5TnHs0KSqmHo3p42NVkIIRRigjFV1XlNIIgO6UTjdpQTcFyQNCSU0XlC1J7tBy9C4fuIvN3L4BYlbEPw==
+    workflow_start_time: 1641880056
+    workflow_end_time: 1641881602
+    workflow_duration: 1546
+    ica_tasks:
+      - ica_task_run_instance_id: trn.a2ba9e0f5dc346d08df674b199a9a7c1
+        task_step_name: main
+        task_name: main
+        task_cpus: 0.8
+        task_memory: 3
+        task_start_time: 1641880174
+        task_stop_time: 1641880775
+        task_duration: 601
+        task_metrics: eJyLjgUAARUAuQ==
+  - ica_workflow_run_instance_id: wfr.32ff48e48bce4d4e8d70efe6fbf92040
+    ica_project_launch_context_id: dc8e6ba9-b744-437b-b070-4cf014694b3d
+    ica_workflow_id: wfl.620ed24f36114e548ba60fe142712eb7
+    ica_workflow_name: samtools-stats_dev-wf
+    ica_workflow_version_name: 1.13.0
+    ica_workflow_run_name: samtools-stats
+    ica_input: eJytjk1rwzAMhv9K8XlJtu6w0NsYdN2lUNhdqLHyAbaVWXK2UfLfZ5fB9gN6EIhX4nmfi+l4AR0jycjOmt1me3+3MVOYk8IZfQ4upnMokjeznxyZfHbcoU4cSjZY2TVN8l0XKyU/VxYVK0tLM5Kj0Lwe3vZwemmOzw/b9qmtC3TNDE5aOvqMDOipoH5fMka01ETqQejjdg7j8NgCOgX8xEgQeHRY93j1ieR5IbBpLjUaE/2FeaLD/wfFOJBCpCEryO0M369cgQN7BsF5oiCQueTP7rvIJ2VhT1Lrl5p1/QFoeJa3
+    ica_output: eJxtkMFugzAQRH8lcq8NGNuAyS2XHvsLyNhrimRwxG5E1Cj/XrsNl7bH2Tea3dk7i1e6XKn3UwB2OtxZiNbQFJck2OjwVJabXwspvFcalB4sKKdAu5aDh8YPvhNc8RLNTDEGPCIZwvInFcv3cyV0q48ESAXdiL0e2GAQFjPndew/ntkaI/3mO4PbN9rtNhjEPHjLFdIAp8+cXUne8C7pD6JLqmHjPMdlC0Vcx9JuIZ/7MsIC696XP5L7+Q83rX2q3yMgJtpPLq9AXAotOy9MratBtEr6QftuMFDZuhMu/UayvyE+BgfrMyOJglfKt6blrpVa1UJwaGquXecqJUDamj2+ANR+gSo=
+    ica_engine_parameters: eJytkLFuwyAQhl8l8pKltgG7jZO1GdohyuD2AYg5LBQbLDjiulHevUDUTh0zwn3/d7r/ms3GnvfKQofGLtlulfXC7cpylraomJR1A3Vz6qAWNTRiQ0DCizzJLSM1KR0f0ZjB5Q45uuxplRmPk8fH+Mq7LHlxnI6PVDuEKYkH0z9IGUzJOPKvtuOIYIOvYn+ltICodB+XjOYCEe3MtNzPetdBojv4WCaIRBteglvxpl4n/z/aqu+EHkAoP0ZGgOR+CECgDkak6XpvZj0YLtaRUL+j4wWsVQJcYK63WDC4Twf3KNdKgsMU5x5NinbzEK+Nn1VBCkYYoYxUdFNRSiMAulc67aQFbQqSB4SSLa0peyahI8vRu3zkLjZz+wGYyM5r
+    workflow_start_time: 1641773346
+    workflow_end_time: 1641776662
+    workflow_duration: 3315
+    ica_tasks:
+      - ica_task_run_instance_id: trn.48c91be6d9c64aee8050ad3b6e64033b
+        task_step_name: main
+        task_name: main
+        task_cpus: 4
+        task_memory: 14
+        task_start_time: 1641773471
+        task_stop_time: 1641775863
+        task_duration: 2392
+        task_metrics: eJyd1MEKwjAMBuBXGTuPkaRJmvkq4kFkBw/FofMgsne33u3A/7YWPprkJzu++/Va5sd6Lkt/6NiVc1YiGbr+sjy/VyPV7zKX2/1VjzTSNnS/lQegWJC3OKa24pYSNUAlYkQ5AUoFqVBDAWWKKCekL3ckryxIhTmQvEIRNe1tSlt5+l8ZCVChUQYmb6xAyiaE9CXIplgSR1QAedVFQSav087/sKkMmoYjm2IeSF457fQl2+kDr/61tw==

--- a/config/run.yaml
+++ b/config/run.yaml
@@ -1521,3 +1521,43 @@ runs:
         task_stop_time: 1643250888
         task_duration: 601
         task_metrics: eJyLjgUAARUAuQ==
+  - ica_workflow_run_instance_id: wfr.10176db758d94e56833422dfd60d0f90
+    ica_project_launch_context_id: dc8e6ba9-b744-437b-b070-4cf014694b3d
+    ica_workflow_id: wfl.5d05d214eb3e4604ba7153118173f63e
+    ica_workflow_name: ghif-qc_dev-wf
+    ica_workflow_version_name: 1.0.1
+    ica_workflow_run_name: qc-ghif-1.0.1
+    ica_input: eJytkEtLZDEQhf+KZO298TFg404HfGwEwX2ozq3OzZikYqrSPSL93ye5ztAOCG5cBMKpwzn11ZuytDUyF+SZwqQuj85Ojo/UxgfB4pMzmwCuq+cnP5ruU65i1hCb9KZsAOb2Uzc+oGrjQBbEU+qam/hS6xqtLYNgzMMEAsOEWz1jwKRv7+5vzONP/XB1era6WI09dN8yqErvaBtggog96q9lYIhCFFgdbL/4ve2fJRe0nnFc9P9tn0baykKxOwtuDOPL94HN7nxlIIiBHRQ0ieYA4wYWyIKRtmimmnuNlIoHsb0S4OOgceeAxk8fNlcHnakWu1Dd3l9dLwNbfJavUWaR3GEK7EbnZa7rylgsJcEko6Wo+RnSDoLeOR7e64YXqyP4pC0EWwMIGttXBodjfl3oBIpDMQVd6+Hvu+jTksvmjiIZhuwxsWm5GNfhtR+7CjFF5FF+i9rv/wC9NfWx
+    ica_output: eJy90sFygyAUBdBfydhto4AKkl03XfYXHAQ0dFQSH5l0msm/V6x2YZM0LpolcHl3OMMpkAdwtsnBCQf5XubSNoVptcrfwbbBZnUKaiuFM8MiqBRsouhYdiFGmFFVsDRTPNEpzeI4IUSViiKFSo6ivVxXW1OucYhCHNmD2x0cRG8vmGQsW4+1U1s4tD2vgkKAbkWjfdlfWZ/rrHU3slNMfwypn6uyFgB+59XU2m+A+fSdPMlYv9o6t+vf2U9pbHusQ9tVkTzWztr6qdKt7iYQdPbDZoTfb30I4B1ud3AtVSKUJ4uVdp2WBvRjdMaymzzzzCWfMbMUiHHKFwOBaPwJjB9pdHJD5T8xTZWhb7nCNM9cYpoyc6fxyjUmHCOK6WKoUUaZLu8lctAA/WlulK8AaMNCFlwxVehEoYRSIUhWEiZZpjJaMEyD30NKWyvdjTP6RUh4TAgrBZcyTQrFRao56pV1/2IcYxycvwAATKiz
+    ica_engine_parameters: eJytkbFywjAMhl+Fy8LSJHYCgbCWoR04hrQP4EZK6mtiu7ZCSjnevba5durIaOv7P52kSzJr+7GXFlvS9pzsFkkPbpfnc2czzvimgrfNegv1CtfVtixXRQEdVAxYV7P8s037d9mlPGMZTx4WiZ7ITHQXXX5zuaCl0RzvaHaEJnoH3d/H6EVROIqvphVEaL2uLP420iCRVH3oMeoTBrTV5nwb6lk5EqrFl7PBQDT+BcLCk3w00/9oI78jekCQ0xgYwE5Mgwc8ddAQq8u9ntWgBSwDIX9LxxNaKwGdZy7XsF50rw5vUaFkh45iXEykY7SdB9J6CJ+ln7dgBeMFK/mm5DzeHVUvVezJfTVjqUc8w2tesToFPOGgTXL9AdFTvpo=
+    workflow_start_time: 1643260552
+    workflow_end_time: 1643264152
+    workflow_duration: 3599
+    ica_tasks:
+      - ica_task_run_instance_id: trn.641edcf776c84605812a2a7a8ef68b40
+        task_step_name: calculate_coverage_step
+        task_name: calculate-coverage__1.0.0.cwl
+        task_cpus: 35.5
+        task_memory: 68
+        task_start_time: 1643260627
+        task_stop_time: 1643261665
+        task_duration: 1037
+        task_metrics: eJyLrlYqycxNLS5JzC1QslIwNDMxNjIzNLAw0FFQSi4oBQnpmQHZuam5+UWVYK5BrY4CVl2GJoa4dBnpWeDSZWRgTI4uM1Pcuixx6TI2tCBHl4U5GbpMTIzI0GWKLzQsa2MBnBt1MQ==
+      - ica_task_run_instance_id: trn.1029dca146d84444b02887196972e447
+        task_step_name: samtools_stats_step
+        task_name: samtools-stats__1.13.0.cwl
+        task_cpus: 4
+        task_memory: 14
+        task_start_time: 1643260648
+        task_stop_time: 1643263027
+        task_duration: 2378
+        task_metrics: eJyd1DEOwjAMBdCrVJmryvlxHMNVEANCHRgiKigDQr07ZScZ/pZEeopjOz59wnqr83O91CUch2iaYBFSxiFcl9fvaJJ9Xed6f7z3rUyyjcN/ZZlQCYlR3lGxpVSVUFk672or6+SwqQyUchCqqBPKxRhlTOYPiIxyol6QTOQQMQqjCnMXwLwLTlQZSZkIVYhfCe3NjabKYCLMTnQvTBlVelO0rZi5Aad6w3vZwHb+Ah14ppE=
+      - ica_task_run_instance_id: trn.73fcd4cbba104292ba9e763a5a3f43a1
+        task_step_name: custom_stats_qc_step
+        task_name: custom-stats-qc__1.0.1.cwl
+        task_cpus: 0.8
+        task_memory: 3
+        task_start_time: 1643263107
+        task_stop_time: 1643263327
+        task_duration: 219
+        task_metrics: eJyLjgUAARUAuQ==

--- a/config/tool.yaml
+++ b/config/tool.yaml
@@ -358,3 +358,10 @@ tools:
         path: 1.0.1/custom-stats-qc__1.0.1.cwl
         md5sum: 56013eeec45343d872fe2565ebb975b9
     categories: []
+  - name: calculate-coverage
+    path: calculate-coverage
+    versions:
+      - name: 1.0.0
+        path: 1.0.0/calculate-coverage__1.0.0.cwl
+        md5sum: d9d29572c4ac71741b90aa6444e122d0
+    categories: []

--- a/config/tool.yaml
+++ b/config/tool.yaml
@@ -346,5 +346,5 @@ tools:
     versions:
       - name: 1.13.0
         path: 1.13.0/samtools-stats__1.13.0.cwl
-        md5sum: 9c47cd04dd39b5e47a93aa48714e7706
+        md5sum: e83bda8efb0b051ef9695ebe7ab45136
     categories: []

--- a/config/tool.yaml
+++ b/config/tool.yaml
@@ -353,5 +353,5 @@ tools:
     versions:
       - name: 1.0.0
         path: 1.0.0/custom-stats-qc__1.0.0.cwl
-        md5sum: 8c221a65a4b39c428461a7b88d1b3b5a
+        md5sum: f0b5d52703ef635066fe9e1003ff61d4
     categories: []

--- a/config/tool.yaml
+++ b/config/tool.yaml
@@ -356,5 +356,5 @@ tools:
         md5sum: 0d33056393a32a0c3033cba31f01f235
       - name: 1.0.1
         path: 1.0.1/custom-stats-qc__1.0.1.cwl
-        md5sum: 733e72c51667c456890a55c9bd957d97
+        md5sum: a1e4a9c75b86aa502f9e5b723b8ee7ea
     categories: []

--- a/config/tool.yaml
+++ b/config/tool.yaml
@@ -356,5 +356,5 @@ tools:
         md5sum: 0d33056393a32a0c3033cba31f01f235
       - name: 1.0.1
         path: 1.0.1/custom-stats-qc__1.0.1.cwl
-        md5sum: 257027ab72cd56ec7a8afa35dabf011f
+        md5sum: 56013eeec45343d872fe2565ebb975b9
     categories: []

--- a/config/tool.yaml
+++ b/config/tool.yaml
@@ -353,5 +353,5 @@ tools:
     versions:
       - name: 1.0.0
         path: 1.0.0/custom-stats-qc__1.0.0.cwl
-        md5sum: f0b5d52703ef635066fe9e1003ff61d4
+        md5sum: 96ccb37f2a7a3307d952df8ba4b7d143
     categories: []

--- a/config/tool.yaml
+++ b/config/tool.yaml
@@ -356,5 +356,5 @@ tools:
         md5sum: 0d33056393a32a0c3033cba31f01f235
       - name: 1.0.1
         path: 1.0.1/custom-stats-qc__1.0.1.cwl
-        md5sum: a1e4a9c75b86aa502f9e5b723b8ee7ea
+        md5sum: 257027ab72cd56ec7a8afa35dabf011f
     categories: []

--- a/config/tool.yaml
+++ b/config/tool.yaml
@@ -341,3 +341,10 @@ tools:
         path: 0.4.1/rnasum__0.4.1.cwl
         md5sum: 4da14840fda49477b166113fdf578677
     categories: []
+  - name: samtools-stats
+    path: samtools-stats
+    versions:
+      - name: 1.13.0
+        path: 1.13.0/samtools-stats__1.13.0.cwl
+        md5sum: 01e4904e82ebf742a323c1762a1df2a7
+    categories: []

--- a/config/tool.yaml
+++ b/config/tool.yaml
@@ -346,5 +346,5 @@ tools:
     versions:
       - name: 1.13.0
         path: 1.13.0/samtools-stats__1.13.0.cwl
-        md5sum: 960df7820ad0d2046af0100e9c3fbfe6
+        md5sum: e83bda8efb0b051ef9695ebe7ab45136
     categories: []

--- a/config/tool.yaml
+++ b/config/tool.yaml
@@ -346,5 +346,5 @@ tools:
     versions:
       - name: 1.13.0
         path: 1.13.0/samtools-stats__1.13.0.cwl
-        md5sum: 01e4904e82ebf742a323c1762a1df2a7
+        md5sum: 960df7820ad0d2046af0100e9c3fbfe6
     categories: []

--- a/config/tool.yaml
+++ b/config/tool.yaml
@@ -346,5 +346,5 @@ tools:
     versions:
       - name: 1.13.0
         path: 1.13.0/samtools-stats__1.13.0.cwl
-        md5sum: e83bda8efb0b051ef9695ebe7ab45136
+        md5sum: 9c47cd04dd39b5e47a93aa48714e7706
     categories: []

--- a/config/tool.yaml
+++ b/config/tool.yaml
@@ -354,4 +354,7 @@ tools:
       - name: 1.0.0
         path: 1.0.0/custom-stats-qc__1.0.0.cwl
         md5sum: 0d33056393a32a0c3033cba31f01f235
+      - name: 1.0.1
+        path: 1.0.1/custom-stats-qc__1.0.1.cwl
+        md5sum: 733e72c51667c456890a55c9bd957d97
     categories: []

--- a/config/tool.yaml
+++ b/config/tool.yaml
@@ -353,5 +353,5 @@ tools:
     versions:
       - name: 1.0.0
         path: 1.0.0/custom-stats-qc__1.0.0.cwl
-        md5sum: 9604a5aa15313c37bd3db9d98548a762
+        md5sum: 0d33056393a32a0c3033cba31f01f235
     categories: []

--- a/config/tool.yaml
+++ b/config/tool.yaml
@@ -348,3 +348,10 @@ tools:
         path: 1.13.0/samtools-stats__1.13.0.cwl
         md5sum: e83bda8efb0b051ef9695ebe7ab45136
     categories: []
+  - name: custom-stats-qc
+    path: custom-stats-qc
+    versions:
+      - name: 1.0.0
+        path: 1.0.0/custom-stats-qc__1.0.0.cwl
+        md5sum: 8c221a65a4b39c428461a7b88d1b3b5a
+    categories: []

--- a/config/tool.yaml
+++ b/config/tool.yaml
@@ -356,7 +356,7 @@ tools:
         md5sum: 0d33056393a32a0c3033cba31f01f235
       - name: 1.0.1
         path: 1.0.1/custom-stats-qc__1.0.1.cwl
-        md5sum: 56013eeec45343d872fe2565ebb975b9
+        md5sum: 92896be3c3c72c53b30ff3f4c4359176
     categories: []
   - name: calculate-coverage
     path: calculate-coverage

--- a/config/tool.yaml
+++ b/config/tool.yaml
@@ -353,5 +353,5 @@ tools:
     versions:
       - name: 1.0.0
         path: 1.0.0/custom-stats-qc__1.0.0.cwl
-        md5sum: 96ccb37f2a7a3307d952df8ba4b7d143
+        md5sum: 9604a5aa15313c37bd3db9d98548a762
     categories: []

--- a/config/workflow.yaml
+++ b/config/workflow.yaml
@@ -146,5 +146,5 @@ workflows:
         md5sum: 2a6cbf08cad667a50a56cc15b396b602
       - name: 1.0.1
         path: 1.0.1/ghif-qc__1.0.1.cwl
-        md5sum: 6842956c9dceb3928b92c80d348776b8
+        md5sum: 731c20f08c7e8cf199b5537e1b9c109b
     categories: []

--- a/config/workflow.yaml
+++ b/config/workflow.yaml
@@ -146,5 +146,5 @@ workflows:
         md5sum: 2a6cbf08cad667a50a56cc15b396b602
       - name: 1.0.1
         path: 1.0.1/ghif-qc__1.0.1.cwl
-        md5sum: 731c20f08c7e8cf199b5537e1b9c109b
+        md5sum: c1def6b4464133d7d5f6fab30d597602
     categories: []

--- a/config/workflow.yaml
+++ b/config/workflow.yaml
@@ -146,5 +146,5 @@ workflows:
         md5sum: 2a6cbf08cad667a50a56cc15b396b602
       - name: 1.0.1
         path: 1.0.1/ghif-qc__1.0.1.cwl
-        md5sum: ab02f516ad47ffb74e83f1f7aeb7c23f
+        md5sum: acc234d7e0c042855e8c9678c696fd24
     categories: []

--- a/config/workflow.yaml
+++ b/config/workflow.yaml
@@ -144,4 +144,7 @@ workflows:
       - name: 1.0.0
         path: 1.0.0/ghif-qc__1.0.0.cwl
         md5sum: 2a6cbf08cad667a50a56cc15b396b602
+      - name: 1.0.1
+        path: 1.0.1/ghif-qc__1.0.1.cwl
+        md5sum: 6842956c9dceb3928b92c80d348776b8
     categories: []

--- a/config/workflow.yaml
+++ b/config/workflow.yaml
@@ -138,3 +138,10 @@ workflows:
         path: 2.0.0--3.9.3/umccrise-with-dragen-germline-pipeline__2.0.0--3.9.3.cwl
         md5sum: fc8cf2baa72d6094dc9da7c4fbf5f7a7
     categories: []
+  - name: ghif-qc
+    path: ghif-qc
+    versions:
+      - name: 1.0.0
+        path: 1.0.0/ghif-qc__1.0.0.cwl
+        md5sum: b33e540b7147b4570f3b7d6c38583aaf
+    categories: []

--- a/config/workflow.yaml
+++ b/config/workflow.yaml
@@ -143,5 +143,5 @@ workflows:
     versions:
       - name: 1.0.0
         path: 1.0.0/ghif-qc__1.0.0.cwl
-        md5sum: b33e540b7147b4570f3b7d6c38583aaf
+        md5sum: 2a6cbf08cad667a50a56cc15b396b602
     categories: []

--- a/config/workflow.yaml
+++ b/config/workflow.yaml
@@ -146,5 +146,5 @@ workflows:
         md5sum: 2a6cbf08cad667a50a56cc15b396b602
       - name: 1.0.1
         path: 1.0.1/ghif-qc__1.0.1.cwl
-        md5sum: c1def6b4464133d7d5f6fab30d597602
+        md5sum: ab02f516ad47ffb74e83f1f7aeb7c23f
     categories: []

--- a/tools/calculate-coverage/1.0.0/calculate-coverage__1.0.0.cwl
+++ b/tools/calculate-coverage/1.0.0/calculate-coverage__1.0.0.cwl
@@ -1,0 +1,115 @@
+cwlVersion: v1.1
+class: CommandLineTool
+
+# Extensions
+$namespaces:
+    s: https://schema.org/
+    ilmn-tes: http://platform.illumina.com/rdf/ica/
+$schemas:
+  - https://schema.org/version/latest/schemaorg-current-http.rdf
+
+# Metadata
+s:author:
+    class: s:Person
+    s:name: Sehrish Kanwal
+    s:email: sehrish.kanwal@umccr.org
+
+# ID/Docs
+id: calculate-coverage--1.0.0
+label: calculate-coverage v(1.0.0)
+doc: |
+    Documentation for calculate-coverage v1.0.0
+    https://github.com/c-BIG/wgs-sample-qc/tree/main/example_implementations/sg-npm 
+
+# ILMN Resources Guide: https://support-docs.illumina.com/SW/ICA/Content/SW/ICA/RequestResources.htm
+hints:
+    ResourceRequirement:
+      ilmn-tes:resources:
+        tier: standard
+        type: standardHiCpu
+        size: medium
+    DockerRequirement:
+        dockerPull: quay.io/umccr/calculate-coverage:1.7
+
+baseCommand: ["python"]
+
+arguments: [$(inputs.script)]
+
+inputs:
+  script:
+    label: script
+    doc: |
+      Path to PRECISE python script on GitHub
+    type: File
+    default:
+      class: File
+      location: https://raw.githubusercontent.com/c-BIG/wgs-sample-qc/main/example_implementations/sg-npm/calculate_coverage.py
+  map_quality:
+    label: map quality
+    doc: |
+      Mapping quality threshold. Default: 20.
+    type: int?
+    inputBinding:
+      prefix: "--mapq"
+  ref_seq:
+    label: ref seq
+    doc: |
+      Path to genome fasta. Required when providing an input CRAM
+    type: File?
+    secondaryFiles:
+      - pattern: ".fai"
+        required: true
+    inputBinding:
+      prefix: "--ref-seq"
+  sample_bam:
+    label: sample bam
+    doc: |
+      Path to input BAM or CRAM
+    type: File
+    secondaryFiles:
+      - pattern: ".bai"
+        required: false
+    streamable: true
+    inputBinding:
+      prefix: "--bam"
+  target_regions:
+    label: input bed
+    doc: |
+      Path to BED file to be used as a mask for metrics calculation. 
+      Only regions in the provided BED will be considered.
+    type: File?
+    inputBinding:
+      prefix: "--bed"
+  out_directory:
+    label: out directory
+    doc: |
+      Path to scratch directory. Default: ./
+    type: Directory?
+    inputBinding:
+      prefix: "--scratch_dir"
+  output_json:
+    label: output json
+    doc: |
+      output file
+    type: string
+    inputBinding:
+      prefix: "--out_json"
+  log_level:
+    label: log level
+    doc: |
+      Set logging level to INFO (default), WARNING or DEBUG.
+    type: string?
+    inputBinding:
+      prefix: "--loglevel"
+
+outputs:
+  output_filename:
+    label: output file
+    doc: |
+      JSON output file containing QC metrics
+    type: File
+    outputBinding:
+      glob: "$(inputs.output_json)"
+
+successCodes:
+  - 0

--- a/tools/custom-stats-qc/1.0.0/custom-stats-qc__1.0.0.cwl
+++ b/tools/custom-stats-qc/1.0.0/custom-stats-qc__1.0.0.cwl
@@ -44,65 +44,65 @@ requirements:
           set -xeuo pipefail
 
           # Sample metadata
-          JSON_STRING=\$( jq -n \
-                            --arg sm "$(inputs.sample_id)" \
+          JSON_STRING=\$( jq -n \\
+                            --arg sm "$(inputs.sample_id)" \\
                             '{sampleID: \$sm}' )
-          echo \$JSON_STRING >> "$(inputs.output_filename).txt"
+          echo \$JSON_STRING >> "$(inputs.output_filename).json"
 
           # Extract average base quality
           avg_base_qual=\$(grep -h "SN	average quality" "$(inputs.output_samtools_stats.path)" | cut -f 3)
-          JSON_STRING=\$( jq -n \
-                            --arg des "average base quality" \
-                            --arg src "SN	average quality" \
-                            --arg val "\$avg_base_qual" \
+          JSON_STRING=\$( jq -n \\
+                            --arg des "average base quality" \\
+                            --arg src "SN	average quality" \\
+                            --arg val "\$avg_base_qual" \\
                             '{average_base_quality: {description: \$des, source: \$src, value: \$val}}' )
-          echo \$JSON_STRING >> "$(inputs.output_filename).txt"
+          echo \$JSON_STRING >> "$(inputs.output_filename).json"
 
           # Extract yield_mapped_bp
           yield_mapped_bp=\$(grep -h "SN	bases mapped (cigar)" "$(inputs.output_samtools_stats.path)" | cut -f 3)
-          JSON_STRING=\$( jq -n \
-                            --arg des "yield mapped bp" \
-                            --arg src "SN	bases mapped (cigar)" \
-                            --arg val "\$yield_mapped_bp" \
+          JSON_STRING=\$( jq -n \\
+                            --arg des "yield mapped bp" \\
+                            --arg src "SN	bases mapped (cigar)" \\
+                            --arg val "\$yield_mapped_bp" \\
                             '{yield_mapped_bp: {description: \$des, source: \$src, value: \$val}}' )
-          echo \$JSON_STRING >> "$(inputs.output_filename).txt"
+          echo \$JSON_STRING >> "$(inputs.output_filename).json"
 
           # Extract pct_autosomes_20x
           pct_autosomes_20x=\$(grep -h "SN	percentage of target genome with coverage > 20" "$(inputs.output_samtools_stats.path)" | cut -f 3)
-          JSON_STRING=\$( jq -n \
-                            --arg des "pct autosomes 20x" \
-                            --arg src "SN	percentage of target genome with coverage > 20" \
-                            --arg val "\$pct_autosomes_20x" \
+          JSON_STRING=\$( jq -n \\
+                            --arg des "pct autosomes 20x" \\
+                            --arg src "SN	percentage of target genome with coverage > 20" \\
+                            --arg val "\$pct_autosomes_20x" \\
                             '{pct_autosomes_20x: {description: \$des, source: \$src, value: \$val}}' )
-          echo \$JSON_STRING >> "$(inputs.output_filename).txt"
+          echo \$JSON_STRING >> "$(inputs.output_filename).json"
 
           # Extract pct_discordant_read_pairs
           pct_discordant_reads=\$(grep -h "SN	percentage of properly paired reads (%):" "$(inputs.output_samtools_stats.path)" | cut -f3)
           pdr=\$(awk -vn1="\$pct_discordant_reads" 'BEGIN { print (100 - n1) }')
-          JSON_STRING=\$( jq -n \
-                            --arg des "pct discordant reads" \
-                            --arg src "SN	percentage of properly paired reads (%)" \
-                            --arg val "\$pct_discordant_reads" \
+          JSON_STRING=\$( jq -n \\
+                            --arg des "pct discordant reads" \\
+                            --arg src "SN	percentage of properly paired reads (%)" \\
+                            --arg val "\$pct_discordant_reads" \\
                             '{pct_discordant_reads: {description: \$des, source: \$src, value: \$val}}' )
-          echo \$JSON_STRING >> "$(inputs.output_filename).txt"
+          echo \$JSON_STRING >> "$(inputs.output_filename).json"
 
           # Extract mean_insert_size
           mean_insert_size=\$(grep -h "SN	insert size average:" "$(inputs.output_samtools_stats.path)" | cut -f3)
-          JSON_STRING=\$( jq -n \
-                            --arg des "mean insert size" \
-                            --arg src "SN	insert size average" \
-                            --arg val "\$mean_insert_size" \
+          JSON_STRING=\$( jq -n \\
+                            --arg des "mean insert size" \\
+                            --arg src "SN	insert size average" \\
+                            --arg val "\$mean_insert_size" \\
                             '{mean_insert_size: {description: \$des, source: \$src, value: \$val}}' )
-          echo \$JSON_STRING >> "$(inputs.output_filename).txt"
+          echo \$JSON_STRING >> "$(inputs.output_filename).json"
 
           # Extract Insert_size_SD
           insert_size_sd=\$(grep -h "SN	insert size standard deviation:" "$(inputs.output_samtools_stats.path)" | cut -f3)
-          JSON_STRING=\$( jq -n \
-                            --arg des "insert size sd" \
-                            --arg src "SN	insert size standard deviation" \
-                            --arg val "\$insert_size_sd" \
+          JSON_STRING=\$( jq -n \\
+                            --arg des "insert size sd" \\
+                            --arg src "SN	insert size standard deviation" \\
+                            --arg val "\$insert_size_sd" \\
                             '{insert_size_sd: {description: \$des, source: \$src, value: \$val}}' )
-          echo \$JSON_STRING >> "$(inputs.output_filename).txt"
+          echo \$JSON_STRING >> "$(inputs.output_filename).json"
 
           # Extract pct_mapped_reads where pct_mapped_reads = [(Mapped Reads - Reads MQ0) / Total Reads]
           # RM = Mapped Reads
@@ -112,50 +112,14 @@ requirements:
           R0=\$(grep -h "SN	reads MQ0:" "$(inputs.output_samtools_stats.path)" | cut -f3)
           RT=\$(grep -h "SN	raw total sequences:" "$(inputs.output_samtools_stats.path)" | cut -f3)
           pct_mapped_reads=\$(( 100 * ( $RM - $R0) / $RT ))
-          JSON_STRING=\$( jq -n \
-                            --arg des "pct mapped reads" \
-                            --arg src "pct_mapped_reads = [(Mapped Reads - Reads MQ0) / Total Reads]" \
-                            --arg val "\$pct_mapped_reads" \
+          JSON_STRING=\$( jq -n \\
+                            --arg des "pct mapped reads" \\
+                            --arg src "pct_mapped_reads = [(Mapped Reads - Reads MQ0) / Total Reads]" \\
+                            --arg val "\$pct_mapped_reads" \\
                             '{pct_mapped_reads: {description: \$des, source: \$src, value: \$val}}' )
-          echo \$JSON_STRING >> "$(inputs.output_filename).txt"
+          echo \$JSON_STRING >> "$(inputs.output_filename).json"
 
-          # Extract average base quality
-          avg_base_qual=\$(grep -h "SN	average quality:" "$(inputs.output_samtools_stats.path)" | cut -f 3)
-          echo "average_base_quality: \$avg_base_qual" >> "$(inputs.output_filename).txt"
-
-          # Extract yield_mapped_bp
-          yield_mapped_bp=\$(grep -h "SN	bases mapped (cigar)" "$(inputs.output_samtools_stats.path)" | cut -f 3)
-          echo "yield_mapped_bp:  \$yield_mapped_bp" >> "$(inputs.output_filename).txt"
-
-          # Extract pct_autosomes_20x
-          pct_autosomes_20x=\$(grep -h "SN	percentage of target genome with coverage > 20" "$(inputs.output_samtools_stats.path)" | cut -f 3)
-          echo "pct_autosomes_20x:    \$pct_autosomes_20x" >> "$(inputs.output_filename).txt"
-
-          # Extract pct_discordant_read_pairs
-          pct_discordant_reads=\$(grep -h "SN	percentage of properly paired reads (%):" "$(inputs.output_samtools_stats.path)" | cut -f3)
-          pdr=\$(awk -vn1="$pct_discordant_reads" 'BEGIN { print (100 - n1) }')
-          echo "pct_discordant_reads: \$pdr" >> "$(inputs.output_filename).txt"
-
-          # Extract mean_insert_size
-          mean_insert_size=\$(grep -h "SN	insert size average:" "$(inputs.output_samtools_stats.path)" | cut -f3)
-          echo "mean_insert_size: \$mean_insert_size" >> "$(inputs.output_filename).txt"
-
-          # Extract Insert_size_SD
-          insert_size_sd=\$(grep -h "SN	insert size standard deviation:" "$(inputs.output_samtools_stats.path)" | cut -f3)
-          echo "insert_size_SD:   \$insert_size_sd" >> "$(inputs.output_filename).txt"
-
-          # Extract pct_mapped_reads where pct_mapped_reads = [(Mapped Reads - Reads MQ0) / Total Reads]
-          # RM = Mapped Reads
-          # R0 = Reads MQ0
-          # RT = Total Reads
-          RM=\$(grep -h "SN	reads mapped:" "$(inputs.output_samtools_stats.path)" | cut -f3)
-          R0=\$(grep -h "SN	reads MQ0:" "$(inputs.output_samtools_stats.path)" | cut -f3)
-          RT=\$(grep -h "SN	raw total sequences:" "$(inputs.output_samtools_stats.path)" | cut -f3)
-          pct_mapped_reads=\$(( 100 * ( $RM - $R0) / $RT ))
-          echo "pct_mapped_reads: \$pct_mapped_reads" &>> "$(inputs.output_filename).txt"
-
-          #jq -s -R '[[ split("\n")[] | select(length > 0) | split(": +";"") | {(.[0]): .[1]}] | add]' "$(inputs.output_filename).txt" >> "$(inputs.output_filename).txt"
-
+          jq '.' "$(inputs.output_filename).json" >> "$(inputs.output_filename)_$(inputs.sample_id).json"
 
 baseCommand: [ "sh", "run-custom-qc.sh" ]
 
@@ -183,7 +147,7 @@ outputs:
       Output file containing custom metrics
     type: File
     outputBinding:
-      glob: "$(inputs.output_filename).txt"
+      glob: "$(inputs.output_filename)_$(inputs.sample_id).json"
 
 successCodes:
   - 0

--- a/tools/custom-stats-qc/1.0.0/custom-stats-qc__1.0.0.cwl
+++ b/tools/custom-stats-qc/1.0.0/custom-stats-qc__1.0.0.cwl
@@ -46,7 +46,8 @@ requirements:
           # Sample metadata
           JSON_STRING=\$( jq -n \\
                             --arg sm "$(inputs.sample_id)" \\
-                            '{sampleID: \$sm}' )
+                            '{sampleID: $sm}' )
+          echo "$(inputs.output_json_filename).json"
           echo \$JSON_STRING >> "$(inputs.output_json_filename).json"
 
           # Extract average base quality
@@ -54,8 +55,8 @@ requirements:
           JSON_STRING=\$( jq -n \\
                             --arg des "average base quality" \\
                             --arg src "SN	average quality" \\
-                            --arg val "\$avg_base_qual" \\
-                            '{average_base_quality: {description: \$des, source: \$src, value: \$val}}' )
+                            --arg val "$avg_base_qual" \\
+                            '{average_base_quality: {description: $des, source: $src, value: $val}}' )
           echo \$JSON_STRING >> "$(inputs.output_json_filename).json"
 
           # Extract yield_mapped_bp
@@ -63,8 +64,8 @@ requirements:
           JSON_STRING=\$( jq -n \\
                             --arg des "yield mapped bp" \\
                             --arg src "SN	bases mapped (cigar)" \\
-                            --arg val "\$yield_mapped_bp" \\
-                            '{yield_mapped_bp: {description: \$des, source: \$src, value: \$val}}' )
+                            --arg val "$yield_mapped_bp" \\
+                            '{yield_mapped_bp: {description: $des, source: $src, value: $val}}' )
           echo \$JSON_STRING >> "$(inputs.output_json_filename).json"
 
           # Extract pct_autosomes_20x
@@ -72,8 +73,8 @@ requirements:
           JSON_STRING=\$( jq -n \\
                             --arg des "pct autosomes 20x" \\
                             --arg src "SN	percentage of target genome with coverage > 20" \\
-                            --arg val "\$pct_autosomes_20x" \\
-                            '{pct_autosomes_20x: {description: \$des, source: \$src, value: \$val}}' )
+                            --arg val "$pct_autosomes_20x" \\
+                            '{pct_autosomes_20x: {description: $des, source: $src, value: $val}}' )
           echo \$JSON_STRING >> "$(inputs.output_json_filename).json"
 
           # Extract pct_discordant_read_pairs
@@ -82,8 +83,8 @@ requirements:
           JSON_STRING=\$( jq -n \\
                             --arg des "pct discordant reads" \\
                             --arg src "SN	percentage of properly paired reads (%)" \\
-                            --arg val "\$pct_discordant_reads" \\
-                            '{pct_discordant_reads: {description: \$des, source: \$src, value: \$val}}' )
+                            --arg val "$pct_discordant_reads" \\
+                            '{pct_discordant_reads: {description: $des, source: $src, value: $val}}' )
           echo \$JSON_STRING >> "$(inputs.output_json_filename).json"
 
           # Extract mean_insert_size
@@ -91,8 +92,8 @@ requirements:
           JSON_STRING=\$( jq -n \\
                             --arg des "mean insert size" \\
                             --arg src "SN	insert size average" \\
-                            --arg val "\$mean_insert_size" \\
-                            '{mean_insert_size: {description: \$des, source: \$src, value: \$val}}' )
+                            --arg val "$mean_insert_size" \\
+                            '{mean_insert_size: {description: $des, source: $src, value: $val}}' )
           echo \$JSON_STRING >> "$(inputs.output_json_filename).json"
 
           # Extract Insert_size_SD
@@ -100,8 +101,8 @@ requirements:
           JSON_STRING=\$( jq -n \\
                             --arg des "insert size sd" \\
                             --arg src "SN	insert size standard deviation" \\
-                            --arg val "\$insert_size_sd" \\
-                            '{insert_size_sd: {description: \$des, source: \$src, value: \$val}}' )
+                            --arg val "$insert_size_sd" \\
+                            '{insert_size_sd: {description: $des, source: $src, value: $val}}' )
           echo \$JSON_STRING >> "$(inputs.output_json_filename).json"
 
           # Extract pct_mapped_reads where pct_mapped_reads = [(Mapped Reads - Reads MQ0) / Total Reads]
@@ -115,8 +116,8 @@ requirements:
           JSON_STRING=\$( jq -n \\
                             --arg des "pct mapped reads" \\
                             --arg src "pct_mapped_reads = [(Mapped Reads - Reads MQ0) / Total Reads]" \\
-                            --arg val "\$pct_mapped_reads" \\
-                            '{pct_mapped_reads: {description: \$des, source: \$src, value: \$val}}' )
+                            --arg val "$pct_mapped_reads" \\
+                            '{pct_mapped_reads: {description: $des, source: $src, value: $val}}' )
           echo \$JSON_STRING >> "$(inputs.output_json_filename).json"
 
           jq '.' "$(inputs.output_json_filename).json" >> "$(inputs.output_json_filename)_$(inputs.sample_id).json"

--- a/tools/custom-stats-qc/1.0.0/custom-stats-qc__1.0.0.cwl
+++ b/tools/custom-stats-qc/1.0.0/custom-stats-qc__1.0.0.cwl
@@ -18,7 +18,7 @@ s:author:
 id: custom-stats-qc--1.0.0
 label: custom-stats-qc v(1.0.0)
 doc: |
-    Documentation for custom-stats-qc v1.0.0
+    A tool to extract custom QC metrics from samtools stats output and convert to json format.
 
 # ILMN Resources Guide: https://support-docs.illumina.com/SW/ICA/Content/SW/ICA/RequestResources.htm
 hints:
@@ -47,7 +47,7 @@ requirements:
           JSON_STRING=\$( jq -n \\
                             --arg sm "$(inputs.sample_id)" \\
                             '{sampleID: \$sm}' )
-          echo \$JSON_STRING >> "$(inputs.output_filename).json"
+          echo \$JSON_STRING >> "$(inputs.output_json_filename).json"
 
           # Extract average base quality
           avg_base_qual=\$(grep -h "SN	average quality" "$(inputs.output_samtools_stats.path)" | cut -f 3)
@@ -56,7 +56,7 @@ requirements:
                             --arg src "SN	average quality" \\
                             --arg val "\$avg_base_qual" \\
                             '{average_base_quality: {description: \$des, source: \$src, value: \$val}}' )
-          echo \$JSON_STRING >> "$(inputs.output_filename).json"
+          echo \$JSON_STRING >> "$(inputs.output_json_filename).json"
 
           # Extract yield_mapped_bp
           yield_mapped_bp=\$(grep -h "SN	bases mapped (cigar)" "$(inputs.output_samtools_stats.path)" | cut -f 3)
@@ -65,7 +65,7 @@ requirements:
                             --arg src "SN	bases mapped (cigar)" \\
                             --arg val "\$yield_mapped_bp" \\
                             '{yield_mapped_bp: {description: \$des, source: \$src, value: \$val}}' )
-          echo \$JSON_STRING >> "$(inputs.output_filename).json"
+          echo \$JSON_STRING >> "$(inputs.output_json_filename).json"
 
           # Extract pct_autosomes_20x
           pct_autosomes_20x=\$(grep -h "SN	percentage of target genome with coverage > 20" "$(inputs.output_samtools_stats.path)" | cut -f 3)
@@ -74,7 +74,7 @@ requirements:
                             --arg src "SN	percentage of target genome with coverage > 20" \\
                             --arg val "\$pct_autosomes_20x" \\
                             '{pct_autosomes_20x: {description: \$des, source: \$src, value: \$val}}' )
-          echo \$JSON_STRING >> "$(inputs.output_filename).json"
+          echo \$JSON_STRING >> "$(inputs.output_json_filename).json"
 
           # Extract pct_discordant_read_pairs
           pct_discordant_reads=\$(grep -h "SN	percentage of properly paired reads (%):" "$(inputs.output_samtools_stats.path)" | cut -f3)
@@ -84,7 +84,7 @@ requirements:
                             --arg src "SN	percentage of properly paired reads (%)" \\
                             --arg val "\$pct_discordant_reads" \\
                             '{pct_discordant_reads: {description: \$des, source: \$src, value: \$val}}' )
-          echo \$JSON_STRING >> "$(inputs.output_filename).json"
+          echo \$JSON_STRING >> "$(inputs.output_json_filename).json"
 
           # Extract mean_insert_size
           mean_insert_size=\$(grep -h "SN	insert size average:" "$(inputs.output_samtools_stats.path)" | cut -f3)
@@ -93,7 +93,7 @@ requirements:
                             --arg src "SN	insert size average" \\
                             --arg val "\$mean_insert_size" \\
                             '{mean_insert_size: {description: \$des, source: \$src, value: \$val}}' )
-          echo \$JSON_STRING >> "$(inputs.output_filename).json"
+          echo \$JSON_STRING >> "$(inputs.output_json_filename).json"
 
           # Extract Insert_size_SD
           insert_size_sd=\$(grep -h "SN	insert size standard deviation:" "$(inputs.output_samtools_stats.path)" | cut -f3)
@@ -102,7 +102,7 @@ requirements:
                             --arg src "SN	insert size standard deviation" \\
                             --arg val "\$insert_size_sd" \\
                             '{insert_size_sd: {description: \$des, source: \$src, value: \$val}}' )
-          echo \$JSON_STRING >> "$(inputs.output_filename).json"
+          echo \$JSON_STRING >> "$(inputs.output_json_filename).json"
 
           # Extract pct_mapped_reads where pct_mapped_reads = [(Mapped Reads - Reads MQ0) / Total Reads]
           # RM = Mapped Reads
@@ -117,9 +117,9 @@ requirements:
                             --arg src "pct_mapped_reads = [(Mapped Reads - Reads MQ0) / Total Reads]" \\
                             --arg val "\$pct_mapped_reads" \\
                             '{pct_mapped_reads: {description: \$des, source: \$src, value: \$val}}' )
-          echo \$JSON_STRING >> "$(inputs.output_filename).json"
+          echo \$JSON_STRING >> "$(inputs.output_json_filename).json"
 
-          jq '.' "$(inputs.output_filename).json" >> "$(inputs.output_filename)_$(inputs.sample_id).json"
+          jq '.' "$(inputs.output_json_filename).json" >> "$(inputs.output_json_filename)_$(inputs.sample_id).json"
 
 baseCommand: [ "sh", "run-custom-qc.sh" ]
 
@@ -134,20 +134,20 @@ inputs:
     doc: |
       Output txt file from samtools stats
     type: File
-  output_filename:
+  output_json_filename:
     label: output filename
     doc: |
       output file
     type: string
 
 outputs:
-  output_file:
+  output_json:
     label: output file
     doc: |
-      Output file containing custom metrics
+      JSON output file containing custom metrics
     type: File
     outputBinding:
-      glob: "$(inputs.output_filename)_$(inputs.sample_id).json"
+      glob: "$(inputs.output_json_filename)_$(inputs.sample_id).json"
 
 successCodes:
   - 0

--- a/tools/custom-stats-qc/1.0.0/custom-stats-qc__1.0.0.cwl
+++ b/tools/custom-stats-qc/1.0.0/custom-stats-qc__1.0.0.cwl
@@ -28,9 +28,9 @@ hints:
             type: standard
             size: small
         coresMin: 1
-        ramMin: 1000
+        ramMin: 4000
     DockerRequirement:
-        dockerPull: alpine:latest
+        dockerPull: bash:latest
 
 requirements:
   InlineJavascriptRequirement: {}
@@ -44,41 +44,41 @@ requirements:
           set -euo pipefail
 
           # Extract average base quality
-          avg_base_qual=$(grep -h "SN	average quality" "$(inputs.output_samtools_stats)" | cut -f 3)
-          echo "average_base_quality: $avg_base_qual" >> "$(inputs.output_filename).txt"
+          avg_base_qual=\$(grep -h "SN	average quality:" "$(inputs.output_samtools_stats.path)" | cut -f 3)
+          echo "average_base_quality: \$avg_base_qual" >> "$(inputs.output_filename).txt"
 
           # Extract yield_mapped_bp
-          yield_mapped_bp=$(grep -h "SN	bases mapped (cigar)" "$(inputs.output_samtools_stats)" | cut -f 3)
-          echo "yield_mapped_bp:  $yield_mapped_bp" >> "$(inputs.output_filename).txt"
+          yield_mapped_bp=\$(grep -h "SN	bases mapped (cigar)" "$(inputs.output_samtools_stats.path)" | cut -f 3)
+          echo "yield_mapped_bp:  \$yield_mapped_bp" >> "$(inputs.output_filename).txt"
 
           # Extract pct_autosomes_20x
-          pct_autosomes_20x=$(grep -h "SN	percentage of target genome with coverage > 20" "$(inputs.output_samtools_stats)" | cut -f 3)
-          echo "pct_autosomes_20x:    $pct_autosomes_20x" >> "$(inputs.output_filename).txt"
+          pct_autosomes_20x=\$(grep -h "SN	percentage of target genome with coverage > 20" "$(inputs.output_samtools_stats.path)" | cut -f 3)
+          echo "pct_autosomes_20x:    \$pct_autosomes_20x" >> "$(inputs.output_filename).txt"
 
           # Extract pct_discordant_read_pairs
-          pct_discordant_reads=$(grep -h "SN	percentage of properly paired reads (%):" "$(inputs.output_samtools_stats)" | cut -f3)
-          pdr=$(awk -vn1="$pct_discordant_reads" 'BEGIN { print (100 - n1) }')
-          echo "pct_discordant_reads: $pdr" >> "$(inputs.output_filename).txt"
+          pct_discordant_reads=\$(grep -h "SN	percentage of properly paired reads (%):" "$(inputs.output_samtools_stats.path)" | cut -f3)
+          pdr=\$(awk -vn1="$pct_discordant_reads" 'BEGIN { print (100 - n1) }')
+          echo "pct_discordant_reads: \$pdr" >> "$(inputs.output_filename).txt"
 
           # Extract mean_insert_size
-          mean_insert_size=$(grep -h "SN	insert size average:" "$(inputs.output_samtools_stats)" | cut -f3)
-          echo "mean_insert_size: $mean_insert_size" >> "$(inputs.output_filename).txt"
+          mean_insert_size=\$(grep -h "SN	insert size average:" "$(inputs.output_samtools_stats.path)" | cut -f3)
+          echo "mean_insert_size: \$mean_insert_size" >> "$(inputs.output_filename).txt"
 
           # Extract Insert_size_SD
-          insert_size_sd=$(grep -h "SN	insert size standard deviation:" "$(inputs.output_samtools_stats)" | cut -f3)
-          echo "insert_size_SD:   $insert_size_sd" >> "$(inputs.output_filename).txt"
+          insert_size_sd=\$(grep -h "SN	insert size standard deviation:" "$(inputs.output_samtools_stats.path)" | cut -f3)
+          echo "insert_size_SD:   \$insert_size_sd" >> "$(inputs.output_filename).txt"
 
           # Extract pct_mapped_reads where pct_mapped_reads = [(Mapped Reads - Reads MQ0) / Total Reads]
           # RM = Mapped Reads
           # R0 = Reads MQ0
           # RT = Total Reads
-          RM=$(grep -h "SN	reads mapped:" "$(inputs.output_samtools_stats)" | cut -f3)
-          R0=$(grep -h "SN	reads MQ0:" "$(inputs.output_samtools_stats)" | cut -f3)
-          RT=$(grep -h "SN	raw total sequences:" "$(inputs.output_samtools_stats)" | cut -f3)
-          pct_mapped_reads=$(( 100 * ( $RM - $R0) / $RT ))
-          echo "pct_mapped_reads: $pct_mapped_reads" &>> "$(inputs.output_filename).txt"
+          RM=\$(grep -h "SN	reads mapped:" "$(inputs.output_samtools_stats.path)" | cut -f3)
+          R0=\$(grep -h "SN	reads MQ0:" "$(inputs.output_samtools_stats.path)" | cut -f3)
+          RT=\$(grep -h "SN	raw total sequences:" "$(inputs.output_samtools_stats.path)" | cut -f3)
+          pct_mapped_reads=\$(( 100 * ( $RM - $R0) / $RT ))
+          echo "pct_mapped_reads: \$pct_mapped_reads" &>> "$(inputs.output_filename).txt"
 
-          jq -s -R '[[ split("\n")[] | select(length > 0) | split(": +";"") | {(.[0]): .[1]}] | add]' "$(inputs.output_filename).txt" >> "$(inputs.output_filename).txt"
+          #jq -s -R '[[ split("\n")[] | select(length > 0) | split(": +";"") | {(.[0]): .[1]}] | add]' "$(inputs.output_filename).txt" >> "$(inputs.output_filename).txt"
 
 
 baseCommand: [ "bash", "run-custom-qc.sh" ]

--- a/tools/custom-stats-qc/1.0.0/custom-stats-qc__1.0.0.cwl
+++ b/tools/custom-stats-qc/1.0.0/custom-stats-qc__1.0.0.cwl
@@ -1,0 +1,108 @@
+cwlVersion: v1.1
+class: CommandLineTool
+
+# Extensions
+$namespaces:
+    s: https://schema.org/
+    ilmn-tes: http://platform.illumina.com/rdf/ica/
+$schemas:
+  - https://schema.org/version/latest/schemaorg-current-http.rdf
+
+# Metadata
+s:author:
+    class: s:Person
+    s:name: Sehrish Kanwal
+    s:email: sehrish.kanwal@umccr.org
+
+# ID/Docs
+id: custom-stats-qc--1.0.0
+label: custom-stats-qc v(1.0.0)
+doc: |
+    Documentation for custom-stats-qc v1.0.0
+
+# ILMN Resources Guide: https://support-docs.illumina.com/SW/ICA/Content/SW/ICA/RequestResources.htm
+hints:
+    ResourceRequirement:
+        ilmn-tes:resources:
+            tier: standard
+            type: standard
+            size: small
+        coresMin: 1
+        ramMin: 1000
+    DockerRequirement:
+        dockerPull: alpine:latest
+
+requirements:
+  InlineJavascriptRequirement: {}
+  InitialWorkDirRequirement:
+    listing:
+      - entryname: "run-custom-qc.sh"
+        entry: |
+          #!/usr/bin/env bash
+
+          # Set up for failure
+          set -euo pipefail
+
+          # Extract average base quality
+          avg_base_qual=$(grep -h "SN	average quality" "$(inputs.output_samtools_stats)" | cut -f 3)
+          echo "average_base_quality: $avg_base_qual" >> "$(inputs.output_filename).txt"
+
+          # Extract yield_mapped_bp
+          yield_mapped_bp=$(grep -h "SN	bases mapped (cigar)" "$(inputs.output_samtools_stats)" | cut -f 3)
+          echo "yield_mapped_bp:  $yield_mapped_bp" >> "$(inputs.output_filename).txt"
+
+          # Extract pct_autosomes_20x
+          pct_autosomes_20x=$(grep -h "SN	percentage of target genome with coverage > 20" "$(inputs.output_samtools_stats)" | cut -f 3)
+          echo "pct_autosomes_20x:    $pct_autosomes_20x" >> "$(inputs.output_filename).txt"
+
+          # Extract pct_discordant_read_pairs
+          pct_discordant_reads=$(grep -h "SN	percentage of properly paired reads (%):" "$(inputs.output_samtools_stats)" | cut -f3)
+          pdr=$(awk -vn1="$pct_discordant_reads" 'BEGIN { print (100 - n1) }')
+          echo "pct_discordant_reads: $pdr" >> "$(inputs.output_filename).txt"
+
+          # Extract mean_insert_size
+          mean_insert_size=$(grep -h "SN	insert size average:" "$(inputs.output_samtools_stats)" | cut -f3)
+          echo "mean_insert_size: $mean_insert_size" >> "$(inputs.output_filename).txt"
+
+          # Extract Insert_size_SD
+          insert_size_sd=$(grep -h "SN	insert size standard deviation:" "$(inputs.output_samtools_stats)" | cut -f3)
+          echo "insert_size_SD:   $insert_size_sd" >> "$(inputs.output_filename).txt"
+
+          # Extract pct_mapped_reads where pct_mapped_reads = [(Mapped Reads - Reads MQ0) / Total Reads]
+          # RM = Mapped Reads
+          # R0 = Reads MQ0
+          # RT = Total Reads
+          RM=$(grep -h "SN	reads mapped:" "$(inputs.output_samtools_stats)" | cut -f3)
+          R0=$(grep -h "SN	reads MQ0:" "$(inputs.output_samtools_stats)" | cut -f3)
+          RT=$(grep -h "SN	raw total sequences:" "$(inputs.output_samtools_stats)" | cut -f3)
+          pct_mapped_reads=$(( 100 * ( $RM - $R0) / $RT ))
+          echo "pct_mapped_reads: $pct_mapped_reads" &>> "$(inputs.output_filename).txt"
+
+          jq -s -R '[[ split("\n")[] | select(length > 0) | split(": +";"") | {(.[0]): .[1]}] | add]' "$(inputs.output_filename).txt" >> "$(inputs.output_filename).txt"
+
+
+baseCommand: [ "bash", "run-custom-qc.sh" ]
+
+inputs:
+  output_samtools_stats:
+    label: output samtools stats
+    doc: |
+      Output txt file from samtools stats
+    type: File
+  output_filename:
+    label: output filename
+    doc: |
+      output file
+    type: string
+
+outputs:
+  output_file:
+    label: output file
+    doc: |
+      Output file containing custom metrics
+    type: File
+    outputBinding:
+      glob: "$(inputs.output_filename).txt"
+
+successCodes:
+  - 0

--- a/tools/custom-stats-qc/1.0.0/custom-stats-qc__1.0.0.cwl
+++ b/tools/custom-stats-qc/1.0.0/custom-stats-qc__1.0.0.cwl
@@ -30,7 +30,7 @@ hints:
         coresMin: 1
         ramMin: 4000
     DockerRequirement:
-        dockerPull: bash:latest
+        dockerPull: quay.io/umccr/alpine-jq:1.6
 
 requirements:
   InlineJavascriptRequirement: {}
@@ -38,10 +38,86 @@ requirements:
     listing:
       - entryname: "run-custom-qc.sh"
         entry: |
-          #!/usr/bin/env bash
+          #!/usr/bin/env sh
 
           # Set up for failure
-          set -euo pipefail
+          set -xeuo pipefail
+
+          # Sample metadata
+          JSON_STRING=\$( jq -n \
+                            --arg sm "$(inputs.sample_id)" \
+                            '{sampleID: \$sm}' )
+          echo \$JSON_STRING >> "$(inputs.output_filename).txt"
+
+          # Extract average base quality
+          avg_base_qual=\$(grep -h "SN	average quality" "$(inputs.output_samtools_stats.path)" | cut -f 3)
+          JSON_STRING=\$( jq -n \
+                            --arg des "average base quality" \
+                            --arg src "SN	average quality" \
+                            --arg val "\$avg_base_qual" \
+                            '{average_base_quality: {description: \$des, source: \$src, value: \$val}}' )
+          echo \$JSON_STRING >> "$(inputs.output_filename).txt"
+
+          # Extract yield_mapped_bp
+          yield_mapped_bp=\$(grep -h "SN	bases mapped (cigar)" "$(inputs.output_samtools_stats.path)" | cut -f 3)
+          JSON_STRING=\$( jq -n \
+                            --arg des "yield mapped bp" \
+                            --arg src "SN	bases mapped (cigar)" \
+                            --arg val "\$yield_mapped_bp" \
+                            '{yield_mapped_bp: {description: \$des, source: \$src, value: \$val}}' )
+          echo \$JSON_STRING >> "$(inputs.output_filename).txt"
+
+          # Extract pct_autosomes_20x
+          pct_autosomes_20x=\$(grep -h "SN	percentage of target genome with coverage > 20" "$(inputs.output_samtools_stats.path)" | cut -f 3)
+          JSON_STRING=\$( jq -n \
+                            --arg des "pct autosomes 20x" \
+                            --arg src "SN	percentage of target genome with coverage > 20" \
+                            --arg val "\$pct_autosomes_20x" \
+                            '{pct_autosomes_20x: {description: \$des, source: \$src, value: \$val}}' )
+          echo \$JSON_STRING >> "$(inputs.output_filename).txt"
+
+          # Extract pct_discordant_read_pairs
+          pct_discordant_reads=\$(grep -h "SN	percentage of properly paired reads (%):" "$(inputs.output_samtools_stats.path)" | cut -f3)
+          pdr=\$(awk -vn1="\$pct_discordant_reads" 'BEGIN { print (100 - n1) }')
+          JSON_STRING=\$( jq -n \
+                            --arg des "pct discordant reads" \
+                            --arg src "SN	percentage of properly paired reads (%)" \
+                            --arg val "\$pct_discordant_reads" \
+                            '{pct_discordant_reads: {description: \$des, source: \$src, value: \$val}}' )
+          echo \$JSON_STRING >> "$(inputs.output_filename).txt"
+
+          # Extract mean_insert_size
+          mean_insert_size=\$(grep -h "SN	insert size average:" "$(inputs.output_samtools_stats.path)" | cut -f3)
+          JSON_STRING=\$( jq -n \
+                            --arg des "mean insert size" \
+                            --arg src "SN	insert size average" \
+                            --arg val "\$mean_insert_size" \
+                            '{mean_insert_size: {description: \$des, source: \$src, value: \$val}}' )
+          echo \$JSON_STRING >> "$(inputs.output_filename).txt"
+
+          # Extract Insert_size_SD
+          insert_size_sd=\$(grep -h "SN	insert size standard deviation:" "$(inputs.output_samtools_stats.path)" | cut -f3)
+          JSON_STRING=\$( jq -n \
+                            --arg des "insert size sd" \
+                            --arg src "SN	insert size standard deviation" \
+                            --arg val "\$insert_size_sd" \
+                            '{insert_size_sd: {description: \$des, source: \$src, value: \$val}}' )
+          echo \$JSON_STRING >> "$(inputs.output_filename).txt"
+
+          # Extract pct_mapped_reads where pct_mapped_reads = [(Mapped Reads - Reads MQ0) / Total Reads]
+          # RM = Mapped Reads
+          # R0 = Reads MQ0
+          # RT = Total Reads
+          RM=\$(grep -h "SN	reads mapped:" "$(inputs.output_samtools_stats.path)" | cut -f3)
+          R0=\$(grep -h "SN	reads MQ0:" "$(inputs.output_samtools_stats.path)" | cut -f3)
+          RT=\$(grep -h "SN	raw total sequences:" "$(inputs.output_samtools_stats.path)" | cut -f3)
+          pct_mapped_reads=\$(( 100 * ( $RM - $R0) / $RT ))
+          JSON_STRING=\$( jq -n \
+                            --arg des "pct mapped reads" \
+                            --arg src "pct_mapped_reads = [(Mapped Reads - Reads MQ0) / Total Reads]" \
+                            --arg val "\$pct_mapped_reads" \
+                            '{pct_mapped_reads: {description: \$des, source: \$src, value: \$val}}' )
+          echo \$JSON_STRING >> "$(inputs.output_filename).txt"
 
           # Extract average base quality
           avg_base_qual=\$(grep -h "SN	average quality:" "$(inputs.output_samtools_stats.path)" | cut -f 3)
@@ -81,9 +157,14 @@ requirements:
           #jq -s -R '[[ split("\n")[] | select(length > 0) | split(": +";"") | {(.[0]): .[1]}] | add]' "$(inputs.output_filename).txt" >> "$(inputs.output_filename).txt"
 
 
-baseCommand: [ "bash", "run-custom-qc.sh" ]
+baseCommand: [ "sh", "run-custom-qc.sh" ]
 
 inputs:
+  sample_id:
+    label: sample id
+    doc: |
+      Id of the input sample
+    type: string
   output_samtools_stats:
     label: output samtools stats
     doc: |

--- a/tools/custom-stats-qc/1.0.1/custom-stats-qc__1.0.1.cwl
+++ b/tools/custom-stats-qc/1.0.1/custom-stats-qc__1.0.1.cwl
@@ -1,0 +1,143 @@
+cwlVersion: v1.1
+class: CommandLineTool
+
+# Extensions
+$namespaces:
+    s: https://schema.org/
+    ilmn-tes: http://platform.illumina.com/rdf/ica/
+$schemas:
+  - https://schema.org/version/latest/schemaorg-current-http.rdf
+
+# Metadata
+s:author:
+    class: s:Person
+    s:name: Sehrish Kanwal
+    s:email: sehrish.kanwal@umccr.org
+
+# ID/Docs
+id: custom-stats-qc--1.0.1
+label: custom-stats-qc v(1.0.1)
+doc: |
+    Documentation for custom-stats-qc v1.0.1
+
+# ILMN Resources Guide: https://support-docs.illumina.com/SW/ICA/Content/SW/ICA/RequestResources.htm
+hints:
+    ResourceRequirement:
+        ilmn-tes:resources:
+            tier: standard
+            type: standard
+            size: small
+        coresMin: 1
+        ramMin: 4000
+    DockerRequirement:
+        dockerPull: quay.io/umccr/alpine-jq:1.6-arm64
+
+requirements:
+  InlineJavascriptRequirement: {}
+  InitialWorkDirRequirement:
+    listing:
+      - entryname: "run-custom-qc.sh"
+        entry: |
+          #!/usr/bin/env bash
+            
+          # Set up for failure
+          set -xeuo pipefail
+
+          get_json_str_from_stats_file(){
+            local pattern="\$1"
+            local stats_file="\$2"
+            local key="\$3"
+            local description="\$4"
+            local value
+            # Get value from file and then parse through jq
+            value="\$(grep "\${pattern}" "\${stats_file}" | cut -f2)"
+            # Return json string
+            # https://unix.stackexchange.com/questions/676634/creating-a-nested-json-file-from-variables-using-jq
+            jq -n \\
+                --arg des "\$description" \\
+                --arg src "samtools:1.13--h8c37831_0" \\
+                --arg val "\$value" \\
+                --arg key_name "\$key" \\
+                --argjson detail "{\\"MIN_BQ\\": 0, \\"MIN_MQ\\": 20, \\"DUP\\": \\"false\\", \\"SEC\\": \\"false\\", \\"CLP\\": \\"false\\", \\"OLP\\": \\"false\\"}" \\
+                '{(\$key_name): {description: \$des, source: \$src, implementation_details: \$detail, value: \$val}}'
+          }
+          # Extract Summary Number section from stats file
+          samtools_stats_file="summary_numbers.txt" 
+          grep ^SN "$(inputs.output_samtools_stats.path)" | cut -f 2- > "\${samtools_stats_file}"
+
+          # Sample metadata
+          JSON_STRING=\$( jq -n \\
+                            --arg des "sample id" \\
+                            --arg src "GIAB" \\
+                            --arg val "NA12878" \\\
+                            '{input: {description: \$des, source: \$src, value: \$val}}' )
+
+          # embedded new line in a variable in bash https://stackoverflow.com/questions/9139401/trying-to-embed-newline-in-a-variable-in-bash
+          # Extract average base quality
+          JSON_STRING="\${JSON_STRING}"\$'\\n'"\$(get_json_str_from_stats_file "average quality" "\${samtools_stats_file}" "average_base_quality" "average base quality")"
+
+          # Extract yield_mapped_bp
+          JSON_STRING="\${JSON_STRING}"\$'\\n'"\$(get_json_str_from_stats_file "bases mapped (cigar)" "\${samtools_stats_file}" "yield_mapped_bp" "yield mapped bp")"
+
+          # Extract pct_autosomes_20x
+          JSON_STRING="\${JSON_STRING}"\$'\\n'"\$(get_json_str_from_stats_file "percentage of target genome with coverage > 20" "\${samtools_stats_file}" "pct_autosomes_20x" "pct autosomes 20x")"
+
+          # Extract mean_insert_size
+          JSON_STRING="\${JSON_STRING}"\$'\\n'"\$(get_json_str_from_stats_file "insert size average:" "\${samtools_stats_file}" "mean_insert_size" "mean insert size")"
+
+          # Extract insert_size_SD
+          JSON_STRING="\${JSON_STRING}"\$'\\n'"\$(get_json_str_from_stats_file "insert size standard deviation:" "\${samtools_stats_file}" "insert_size_sd" "insert size sd")"
+
+          # Extract pct_discordant_read_pairs
+          pct_properly_paired_reads=\$(grep -h "percentage of properly paired reads (%):" "\${samtools_stats_file}" | cut -f2)
+          pdr=\$(awk -vn1="$pct_properly_paired_reads" 'BEGIN { print (100 - n1) }')
+          JSON_STRING="\${JSON_STRING}"\$'\\n'"\$( jq -n \\
+                          --arg des "pct discordant paired reads" \\
+                          --arg src "samtools:1.13--h8c37831_0" \\
+                          --arg val "\$pdr" \\
+                          --argjson detail "[{\\"MIN_BQ\\": 0, \\"MIN_MQ\\": 20, \\"DUP\\": \\"false\\", \\"SEC\\": \\"false\\", \\"CLP\\": \\"false\\", \\"OLP\\": \\"false\\"}]" \\
+                          '{pct_discordant_reads: {description: \$des, source: \$src, implementation_details: \$detail, value: \$val}}' )"
+
+          # Extract pct_mapped_reads where pct_mapped_reads = [(Mapped Reads - Reads MQ0) / Total Reads]
+          # RM = Mapped Reads
+          # R0 = Reads MQ0
+          # RT = Total Reads
+          RM=\$(grep -h "reads mapped:" "\${samtools_stats_file}" | cut -f2)
+          R0=\$(grep -h "reads MQ0:" "\${samtools_stats_file}" | cut -f2)
+          RT=\$(grep -h "raw total sequences:" "\${samtools_stats_file}" | cut -f2)
+          pct_mapped_reads=\$(( 100 * ( \$RM - \$R0) / \$RT ))
+          JSON_STRING="\${JSON_STRING}"$'\\n'"\$( jq -n \\
+                          --arg des "pct mapped reads" \\
+                          --arg src "samtools:1.13--h8c37831_0" \\
+                          --arg val "\$pct_mapped_reads" \\
+                          --argjson detail "[{\\"MIN_BQ\\": 0, \\"MIN_MQ\\": 20, \\"DUP\\": \\"false\\", \\"SEC\\": \\"false\\", \\"CLP\\": \\"false\\", \\"OLP\\": \\"false\\"}]" \\
+                          '{pct_mapped_reads: {description: \$des, source: \$src, implementation_details: \$detail, value: \$val}}' )"
+
+          # Write output to file
+          echo \$JSON_STRING | jq -n '. |= [inputs]' > "$(inputs.output_json_filename).json"
+
+baseCommand: [ "bash", "run-custom-qc.sh" ]
+
+inputs:
+  output_samtools_stats:
+    label: output samtools stats
+    doc: |
+      Output txt file from samtools stats
+    type: File
+  output_json_filename:
+    label: output filename
+    doc: |
+      output file
+    type: string
+
+outputs:
+  output_json:
+    label: output file
+    doc: |
+      JSON output file containing custom metrics
+    type: File
+    outputBinding:
+      glob: "$(inputs.output_json_filename).json"
+
+successCodes:
+  - 0

--- a/tools/custom-stats-qc/1.0.1/custom-stats-qc__1.0.1.cwl
+++ b/tools/custom-stats-qc/1.0.1/custom-stats-qc__1.0.1.cwl
@@ -58,7 +58,7 @@ requirements:
                 --arg src "samtools:1.13--h8c37831_0" \\
                 --arg val "$value" \\
                 --arg key_name "$key" \\
-                --argjson detail "{\\"MIN_BQ\\": 0, \\"MIN_MQ\\": 20, \\"DUP\\": \\"false\\", \\"SEC\\": \\"false\\", \\"CLP\\": \\"false\\", \\"OLP\\": \\"false\\"}" \\
+                --argjson detail "{\\"MIN_BQ\\": 0, \\"MIN_MQ\\": 0, \\"DUP\\": \\"false\\", \\"SEC\\": \\"false\\", \\"SUP\\": \\"false\\", \\"CLP\\": \\"false\\", \\"OLP\\": \\"false\\"}" \\
                 '{($key_name): {description: $des, source: $src, implementation_details: $detail, value: $val}}'
           }
           # Extract Summary Number section from stats file
@@ -95,7 +95,7 @@ requirements:
                           --arg des "pct discordant paired reads" \\
                           --arg src "samtools:1.13--h8c37831_0" \\
                           --arg val "$pdr" \\
-                          --argjson detail "[{\\"MIN_BQ\\": 0, \\"MIN_MQ\\": 20, \\"DUP\\": \\"false\\", \\"SEC\\": \\"false\\", \\"CLP\\": \\"false\\", \\"OLP\\": \\"false\\"}]" \\
+                          --argjson detail "[{\\"MIN_BQ\\": 0, \\"MIN_MQ\\": 0, \\"DUP\\": \\"false\\", \\"SEC\\": \\"false\\", \\"SUP\\": \\"false\\", \\"CLP\\": \\"false\\", \\"OLP\\": \\"false\\"}]" \\
                           '{pct_discordant_reads: {description: $des, source: $src, implementation_details: $detail, value: $val}}' )"
 
           # Extract pct_mapped_reads where pct_mapped_reads = [(Mapped Reads - Reads MQ0) / Total Reads]
@@ -110,7 +110,7 @@ requirements:
                           --arg des "pct mapped reads" \\
                           --arg src "samtools:1.13--h8c37831_0" \\
                           --arg val "$pct_mapped_reads" \\
-                          --argjson detail "[{\\"MIN_BQ\\": 0, \\"MIN_MQ\\": 20, \\"DUP\\": \\"false\\", \\"SEC\\": \\"false\\", \\"CLP\\": \\"false\\", \\"OLP\\": \\"false\\"}]" \\
+                          --argjson detail "[{\\"MIN_BQ\\": 0, \\"MIN_MQ\\": 0, \\"DUP\\": \\"false\\", \\"SEC\\": \\"false\\", \\"SUP\\": \\"false\\", \\"CLP\\": \\"false\\", \\"OLP\\": \\"false\\"}]" \\
                           '{pct_mapped_reads: {description: $des, source: $src, implementation_details: $detail, value: $val}}' )"
 
           # Write output to file

--- a/tools/custom-stats-qc/1.0.1/custom-stats-qc__1.0.1.cwl
+++ b/tools/custom-stats-qc/1.0.1/custom-stats-qc__1.0.1.cwl
@@ -30,7 +30,7 @@ hints:
         coresMin: 1
         ramMin: 4000
     DockerRequirement:
-        dockerPull: quay.io/umccr/alpine-jq:1.6-arm64
+        dockerPull: quay.io/umccr/alpine-jq:1.6-amd64
 
 requirements:
   InlineJavascriptRequirement: {}

--- a/tools/custom-stats-qc/1.0.1/custom-stats-qc__1.0.1.cwl
+++ b/tools/custom-stats-qc/1.0.1/custom-stats-qc__1.0.1.cwl
@@ -116,9 +116,20 @@ requirements:
           # Write output to file
           echo "\${JSON_STRING}" | jq -n '. |= [inputs]' > "$(inputs.output_json_filename).json"
 
+          # Combine PRECISE calculate-coverage script output with UMCCR's
+          cat "$(inputs.precise_json_output.path)" | jq -n '[inputs.qc_metrics]' > tmp.json
+          jq -s 'add' "$(inputs.output_json_filename).json" tmp.json > "$(inputs.output_json_filename)_combined.json"
+
 baseCommand: [ "bash", "run-custom-qc.sh" ]
 
 inputs:
+  # PRESISE QC OUTPUT
+  precise_json_output:
+    label: precise json output
+    doc: |
+      Output file from PRECISE calculate_coverage.py script.
+    type: File
+  # UMCCR QC specific inputs
   sample_id:
     label: sample id
     doc: |
@@ -148,6 +159,13 @@ outputs:
     type: File
     outputBinding:
       glob: "$(inputs.output_json_filename).json"
+  output_json_combined:
+    label: output file combined
+    doc: |
+      JSON output file containing custom metrics comsbined with PRECISE QC implementation
+    type: File
+    outputBinding:
+      glob: "$(inputs.output_json_filename)_combined.json"
 
 successCodes:
   - 0

--- a/tools/custom-stats-qc/1.0.1/custom-stats-qc__1.0.1.cwl
+++ b/tools/custom-stats-qc/1.0.1/custom-stats-qc__1.0.1.cwl
@@ -44,22 +44,22 @@ requirements:
           set -xeuo pipefail
 
           get_json_str_from_stats_file(){
-            local pattern="\$1"
-            local stats_file="\$2"
-            local key="\$3"
-            local description="\$4"
+            local pattern="$1"
+            local stats_file="$2"
+            local key="$3"
+            local description="$4"
             local value
             # Get value from file and then parse through jq
             value="\$(grep "\${pattern}" "\${stats_file}" | cut -f2)"
             # Return json string
             # https://unix.stackexchange.com/questions/676634/creating-a-nested-json-file-from-variables-using-jq
             jq -n \\
-                --arg des "\$description" \\
+                --arg des "$description" \\
                 --arg src "samtools:1.13--h8c37831_0" \\
-                --arg val "\$value" \\
-                --arg key_name "\$key" \\
+                --arg val "$value" \\
+                --arg key_name "$key" \\
                 --argjson detail "{\\"MIN_BQ\\": 0, \\"MIN_MQ\\": 20, \\"DUP\\": \\"false\\", \\"SEC\\": \\"false\\", \\"CLP\\": \\"false\\", \\"OLP\\": \\"false\\"}" \\
-                '{(\$key_name): {description: \$des, source: \$src, implementation_details: \$detail, value: \$val}}'
+                '{($key_name): {description: $des, source: $src, implementation_details: $detail, value: $val}}'
           }
           # Extract Summary Number section from stats file
           samtools_stats_file="summary_numbers.txt" 
@@ -68,35 +68,35 @@ requirements:
           # Sample metadata
           JSON_STRING=\$( jq -n \\
                             --arg des "sample id" \\
-                            --arg src "GIAB" \\
-                            --arg val "NA12878" \\\
-                            '{input: {description: \$des, source: \$src, value: \$val}}' )
+                            --arg src "$(inputs.sample_source)" \\
+                            --arg val "$(inputs.sample_id)" \\
+                            '{input: {description: $des, source: $src, value: $val}}' )
 
           # embedded new line in a variable in bash https://stackoverflow.com/questions/9139401/trying-to-embed-newline-in-a-variable-in-bash
           # Extract average base quality
-          JSON_STRING="\${JSON_STRING}"\$'\\n'"\$(get_json_str_from_stats_file "average quality" "\${samtools_stats_file}" "average_base_quality" "average base quality")"
+          JSON_STRING="\${JSON_STRING}"$'\\n'"\$(get_json_str_from_stats_file "average quality" "\${samtools_stats_file}" "average_base_quality" "average base quality")"
 
           # Extract yield_mapped_bp
-          JSON_STRING="\${JSON_STRING}"\$'\\n'"\$(get_json_str_from_stats_file "bases mapped (cigar)" "\${samtools_stats_file}" "yield_mapped_bp" "yield mapped bp")"
+          JSON_STRING="\${JSON_STRING}"$'\\n'"\$(get_json_str_from_stats_file "bases mapped (cigar)" "\${samtools_stats_file}" "yield_mapped_bp" "yield mapped bp")"
 
           # Extract pct_autosomes_20x
-          JSON_STRING="\${JSON_STRING}"\$'\\n'"\$(get_json_str_from_stats_file "percentage of target genome with coverage > 20" "\${samtools_stats_file}" "pct_autosomes_20x" "pct autosomes 20x")"
+          JSON_STRING="\${JSON_STRING}"$'\\n'"\$(get_json_str_from_stats_file "percentage of target genome with coverage > 20" "\${samtools_stats_file}" "pct_autosomes_20x" "pct autosomes 20x")"
 
           # Extract mean_insert_size
-          JSON_STRING="\${JSON_STRING}"\$'\\n'"\$(get_json_str_from_stats_file "insert size average:" "\${samtools_stats_file}" "mean_insert_size" "mean insert size")"
+          JSON_STRING="\${JSON_STRING}"$'\\n'"\$(get_json_str_from_stats_file "insert size average:" "\${samtools_stats_file}" "mean_insert_size" "mean insert size")"
 
           # Extract insert_size_SD
-          JSON_STRING="\${JSON_STRING}"\$'\\n'"\$(get_json_str_from_stats_file "insert size standard deviation:" "\${samtools_stats_file}" "insert_size_sd" "insert size sd")"
+          JSON_STRING="\${JSON_STRING}"$'\\n'"\$(get_json_str_from_stats_file "insert size standard deviation:" "\${samtools_stats_file}" "insert_size_sd" "insert size sd")"
 
           # Extract pct_discordant_read_pairs
           pct_properly_paired_reads=\$(grep -h "percentage of properly paired reads (%):" "\${samtools_stats_file}" | cut -f2)
           pdr=\$(awk -vn1="$pct_properly_paired_reads" 'BEGIN { print (100 - n1) }')
-          JSON_STRING="\${JSON_STRING}"\$'\\n'"\$( jq -n \\
+          JSON_STRING="\${JSON_STRING}"$'\\n'"\$( jq -n \\
                           --arg des "pct discordant paired reads" \\
                           --arg src "samtools:1.13--h8c37831_0" \\
-                          --arg val "\$pdr" \\
+                          --arg val "$pdr" \\
                           --argjson detail "[{\\"MIN_BQ\\": 0, \\"MIN_MQ\\": 20, \\"DUP\\": \\"false\\", \\"SEC\\": \\"false\\", \\"CLP\\": \\"false\\", \\"OLP\\": \\"false\\"}]" \\
-                          '{pct_discordant_reads: {description: \$des, source: \$src, implementation_details: \$detail, value: \$val}}' )"
+                          '{pct_discordant_reads: {description: $des, source: $src, implementation_details: $detail, value: $val}}' )"
 
           # Extract pct_mapped_reads where pct_mapped_reads = [(Mapped Reads - Reads MQ0) / Total Reads]
           # RM = Mapped Reads
@@ -105,20 +105,30 @@ requirements:
           RM=\$(grep -h "reads mapped:" "\${samtools_stats_file}" | cut -f2)
           R0=\$(grep -h "reads MQ0:" "\${samtools_stats_file}" | cut -f2)
           RT=\$(grep -h "raw total sequences:" "\${samtools_stats_file}" | cut -f2)
-          pct_mapped_reads=\$(( 100 * ( \$RM - \$R0) / \$RT ))
+          pct_mapped_reads=\$(( 100 * ( $RM - $R0) / $RT ))
           JSON_STRING="\${JSON_STRING}"$'\\n'"\$( jq -n \\
                           --arg des "pct mapped reads" \\
                           --arg src "samtools:1.13--h8c37831_0" \\
-                          --arg val "\$pct_mapped_reads" \\
+                          --arg val "$pct_mapped_reads" \\
                           --argjson detail "[{\\"MIN_BQ\\": 0, \\"MIN_MQ\\": 20, \\"DUP\\": \\"false\\", \\"SEC\\": \\"false\\", \\"CLP\\": \\"false\\", \\"OLP\\": \\"false\\"}]" \\
-                          '{pct_mapped_reads: {description: \$des, source: \$src, implementation_details: \$detail, value: \$val}}' )"
+                          '{pct_mapped_reads: {description: $des, source: $src, implementation_details: $detail, value: $val}}' )"
 
           # Write output to file
-          echo \$JSON_STRING | jq -n '. |= [inputs]' > "$(inputs.output_json_filename).json"
+          echo "\${JSON_STRING}" | jq -n '. |= [inputs]' > "$(inputs.output_json_filename).json"
 
 baseCommand: [ "bash", "run-custom-qc.sh" ]
 
 inputs:
+  sample_id:
+    label: sample id
+    doc: |
+      Sample identity
+    type: string
+  sample_source:
+    label: sample source
+    doc: |
+      Sample original source
+    type: string
   output_samtools_stats:
     label: output samtools stats
     doc: |

--- a/tools/samtools-stats/1.13.0/samtools-stats__1.13.0.cwl
+++ b/tools/samtools-stats/1.13.0/samtools-stats__1.13.0.cwl
@@ -60,6 +60,9 @@ inputs:
     doc: |
       The BAM file to gather statistics from
     type: File
+    secondaryFiles:
+      - pattern: ".bai"
+        required: false
     inputBinding:
       # After all other arguments
       position: 100
@@ -146,6 +149,9 @@ inputs:
     doc: |
       Reference sequence (required for GC-depth and mismatches-per-cycle calculation). []
     type: File?
+    secondaryFiles:
+      - pattern: ".fai"
+        required: true
     inputBinding:
       prefix: "--ref-seq"
   split:

--- a/tools/samtools-stats/1.13.0/samtools-stats__1.13.0.cwl
+++ b/tools/samtools-stats/1.13.0/samtools-stats__1.13.0.cwl
@@ -45,7 +45,7 @@ requirements:
           set -euo pipefail
 
           # Run stats command, write to output file
-          eval samtools stats '"\${@}"' 1> "$(inputs.output_filename)"
+          eval samtools stats '"\${@}"' 1> "$(inputs.output_filename).txt"
 
 baseCommand: [ "bash", "run-samtools-stats.sh" ]
 
@@ -67,7 +67,7 @@ inputs:
     label: coverage
     doc: |
       Set coverage distribution to the specified range (MIN, MAX, STEP all given as integers) [1,1000,1]
-    type: int[]
+    type: int[]?
     inputBinding:
       prefix: "--coverage"
   remove_dups:
@@ -162,7 +162,7 @@ inputs:
       Do stats in these regions only. Tab-delimited file chr,from,to, 1-based, inclusive. []
     type: File?
     inputBinding:
-      prefix: "--target_regions"
+      prefix: "--target-regions"
   sparse:
     label: sparse
     doc: |
@@ -199,7 +199,7 @@ outputs:
       Output file, of varying format depending on the command run
     type: File
     outputBinding:
-      glob: "$(inputs.output_filename)"
+      glob: "$(inputs.output_filename).txt"
 
 successCodes:
   - 0

--- a/tools/samtools-stats/1.13.0/samtools-stats__1.13.0.cwl
+++ b/tools/samtools-stats/1.13.0/samtools-stats__1.13.0.cwl
@@ -1,0 +1,205 @@
+cwlVersion: v1.1
+class: CommandLineTool
+
+# Extensions
+$namespaces:
+    s: https://schema.org/
+    ilmn-tes: http://platform.illumina.com/rdf/ica/
+$schemas:
+  - https://schema.org/version/latest/schemaorg-current-http.rdf
+
+# Metadata
+s:author:
+    class: s:Person
+    s:name: Sehrish Kanwal
+    s:email: sehrish.kanwal@umccr.org
+
+# ID/Docs
+id: samtools-stats--1.13.0
+label: samtools-stats v(1.13.0)
+doc: |
+    samtools stats collects statistics from BAM files and outputs in a text format. 
+    The output can be visualized graphically using plot-bamstats.
+
+# ILMN Resources Guide: https://support-docs.illumina.com/SW/ICA/Content/SW/ICA/RequestResources.htm
+hints:
+    ResourceRequirement:
+        ilmn-tes:resources:
+            tier: standard
+            type: standard
+            size: xlarge
+        coresMin: 4
+        ramMin: 14000
+    DockerRequirement:
+        dockerPull: quay.io/biocontainers/samtools:1.13--h8c37831_0
+
+requirements:
+  InlineJavascriptRequirement: {}
+  InitialWorkDirRequirement:
+    listing:
+      - entryname: "run-samtools-stats.sh"
+        entry: |
+          #!/usr/bin/env bash
+
+          # Set up for failure
+          set -euo pipefail
+
+          # Run stats command, write to output file
+          eval samtools stats '"\${@}"' 1> "$(inputs.output_filename)"
+
+baseCommand: [ "bash", "run-samtools-stats.sh" ]
+
+inputs:
+  output_filename:
+    label: output filename
+    doc: |
+      Redirects stdout
+    type: string
+  input_bam:
+    label: input BAM 
+    doc: |
+      The BAM file to gather statistics from
+    type: File
+    inputBinding:
+      # After all other arguments
+      position: 100
+  coverage:
+    label: coverage
+    doc: |
+      Set coverage distribution to the specified range (MIN, MAX, STEP all given as integers) [1,1000,1]
+    type: int[]
+    inputBinding:
+      prefix: "--coverage"
+  remove_dups:
+    label: remove dups
+    doc: |
+      Exclude from statistics reads marked as duplicates
+    type: boolean?
+    inputBinding:
+      prefix: "--remove-dups"
+  required_flag:
+    label: required flag
+    doc: |
+      Required flag, 0 for unset. See also `samtools flags` [0]
+    type: int?
+    inputBinding:
+      prefix: "--required-flag"
+  filtering_flag:
+    label: filtering flag
+    doc: |
+      iltering flag, 0 for unset. See also `samtools flags` [0]
+    type: int?
+    inputBinding:
+      prefix: "--filtering-flag"
+  GC_depth:
+    label: GC depth 
+    doc: |
+      the size of GC-depth bins (decreasing bin size increases memory requirement) [2e4]
+    type: float?
+    inputBinding:
+      prefix: "--GC-depth"
+  insert_size:
+    label: insert size 
+    doc: |
+      Maximum insert size [8000]
+    type: int?
+    inputBinding:
+      prefix: "--insert-size"
+  id:
+    label: id
+    doc: |
+      Include only listed read group or sample name []
+    type: string?
+    inputBinding:
+      prefix: "--id"
+  read_length:
+    label: read length 
+    doc: |
+      Include in the statistics only reads with the given read length [-1]
+    type: int?
+    inputBinding:
+      prefix: "--read-length"
+  most_inserts:
+    label: most inserts
+    doc: |
+      Report only the main part of inserts [0.99]
+    type: float?
+    inputBinding:
+      prefix: "--most-inserts"
+  split_prefix:
+    label: split prefix
+    doc: |
+      A path or string prefix to prepend to filenames output when creating categorised 
+      statistics files with -S/--split. [input filename]
+    type: string?
+    inputBinding:
+      prefix: "--split-prefix"
+  trim_quality:
+    label: trim quality
+    doc: |
+      The BWA trimming parameter [0]
+    type: int?
+    inputBinding:
+      prefix: "--trim-quality"
+  ref_seq:
+    label: ref seq
+    doc: |
+      Reference sequence (required for GC-depth and mismatches-per-cycle calculation). []
+    type: File?
+    inputBinding:
+      prefix: "--ref-seq"
+  split:
+    label: split
+    doc: |
+      In addition to the complete statistics, also output categorised statistics based on the tagged field TAG 
+      (e.g., use --split RG to split into read groups).
+    type: string?
+    inputBinding:
+      prefix: "--split"
+  target_regions:
+    label: target regions
+    doc: |
+      Do stats in these regions only. Tab-delimited file chr,from,to, 1-based, inclusive. []
+    type: File?
+    inputBinding:
+      prefix: "--target_regions"
+  sparse:
+    label: sparse
+    doc: |
+      Suppress outputting IS rows where there are no insertions.
+    type: boolean?
+    inputBinding:
+      prefix: "--sparse"
+  remove_overlaps:
+    label: remove overlaps
+    doc: |
+      Remove overlaps of paired-end reads from coverage and base count computations.
+    type: boolean?
+    inputBinding:
+      prefix: "--remove-overlaps"
+  cov_threshold:
+    label: cov threshold
+    doc: |
+      Only bases with coverage above this value will be included in the target percentage computation [0]
+    type: int?
+    inputBinding:
+      prefix: "--cov-threshold"
+  threads:
+    label: threads
+    doc: |
+      Number of input/output compression threads to use in addition to main thread [0].
+    type: int?
+    inputBinding:
+      prefix: "--threads"
+
+outputs:
+  output_file:
+    label: output file
+    doc: |
+      Output file, of varying format depending on the command run
+    type: File
+    outputBinding:
+      glob: "$(inputs.output_filename)"
+
+successCodes:
+  - 0

--- a/tools/samtools-stats/1.13.0/samtools-stats__1.13.0.cwl
+++ b/tools/samtools-stats/1.13.0/samtools-stats__1.13.0.cwl
@@ -45,7 +45,7 @@ requirements:
           set -euo pipefail
 
           # Run stats command, write to output file
-          eval samtools stats '"\${@}"' 1> "$(inputs.output_filename).txt"
+          eval samtools stats '"\${@}"' 1> "$(inputs.output_filename)"
 
 baseCommand: [ "bash", "run-samtools-stats.sh" ]
 
@@ -205,7 +205,7 @@ outputs:
       Output file, of varying format depending on the command run
     type: File
     outputBinding:
-      glob: "$(inputs.output_filename).txt"
+      glob: "$(inputs.output_filename)"
 
 successCodes:
   - 0

--- a/tools/samtools-stats/1.13.0/samtools-stats__1.13.0.cwl
+++ b/tools/samtools-stats/1.13.0/samtools-stats__1.13.0.cwl
@@ -45,7 +45,7 @@ requirements:
           set -euo pipefail
 
           # Run stats command, write to output file
-          eval samtools stats '"\${@}"' 1> "$(inputs.output_filename)"
+          eval samtools stats '"\${@}"' 1> "$(inputs.output_filename).txt"
 
 baseCommand: [ "bash", "run-samtools-stats.sh" ]
 
@@ -205,7 +205,7 @@ outputs:
       Output file, of varying format depending on the command run
     type: File
     outputBinding:
-      glob: "$(inputs.output_filename)"
+      glob: "$(inputs.output_filename).txt"
 
 successCodes:
   - 0

--- a/workflows/ghif-qc/1.0.0/ghif-qc__1.0.0.cwl
+++ b/workflows/ghif-qc/1.0.0/ghif-qc__1.0.0.cwl
@@ -1,0 +1,225 @@
+cwlVersion: v1.1
+class: Workflow
+
+# Extensions
+$namespaces:
+    s: https://schema.org/
+$schemas:
+  - https://schema.org/version/latest/schemaorg-current-http.rdf
+
+# Metadata
+s:author:
+    class: s:Person
+    s:name: Sehrish Kanwal
+    s:email: sehrish.kanwal@umccr.org
+
+# ID/Docs
+id: ghif-qc--1.0.0
+label: ghif-qc v(1.0.0)
+doc: |
+    Documentation for ghif-qc v1.0.0
+
+requirements:
+    InlineJavascriptRequirement: {}
+    ScatterFeatureRequirement: {}
+    MultipleInputFeatureRequirement: {}
+    StepInputExpressionRequirement: {}
+
+inputs:
+  #samtools stats
+  output_filename:
+    label: output filename
+    doc: |
+      Redirects stdout
+    type: string
+  input_bam:
+    label: input BAM 
+    doc: |
+      The BAM file to gather statistics from
+    type: File
+    secondaryFiles:
+      - pattern: ".bai"
+        required: false
+  coverage:
+    label: coverage
+    doc: |
+      Set coverage distribution to the specified range (MIN, MAX, STEP all given as integers) [1,1000,1]
+    type: int[]?
+  remove_dups:
+    label: remove dups
+    doc: |
+      Exclude from statistics reads marked as duplicates
+    type: boolean?
+  required_flag:
+    label: required flag
+    doc: |
+      Required flag, 0 for unset. See also `samtools flags` [0]
+    type: int?
+  filtering_flag:
+    label: filtering flag
+    doc: |
+      iltering flag, 0 for unset. See also `samtools flags` [0]
+    type: int?
+  GC_depth:
+    label: GC depth 
+    doc: |
+      the size of GC-depth bins (decreasing bin size increases memory requirement) [2e4]
+    type: float?
+  insert_size:
+    label: insert size 
+    doc: |
+      Maximum insert size [8000]
+    type: int?
+  id:
+    label: id
+    doc: |
+      Include only listed read group or sample name []
+    type: string?
+  read_length:
+    label: read length 
+    doc: |
+      Include in the statistics only reads with the given read length [-1]
+    type: int?
+  most_inserts:
+    label: most inserts
+    doc: |
+      Report only the main part of inserts [0.99]
+    type: float?
+  split_prefix:
+    label: split prefix
+    doc: |
+      A path or string prefix to prepend to filenames output when creating categorised 
+      statistics files with -S/--split. [input filename]
+    type: string?
+  trim_quality:
+    label: trim quality
+    doc: |
+      The BWA trimming parameter [0]
+    type: int?
+  ref_seq:
+    label: ref seq
+    doc: |
+      Reference sequence (required for GC-depth and mismatches-per-cycle calculation). []
+    type: File?
+    secondaryFiles:
+      - pattern: ".fai"
+        required: true
+  split:
+    label: split
+    doc: |
+      In addition to the complete statistics, also output categorised statistics based on the tagged field TAG 
+      (e.g., use --split RG to split into read groups).
+    type: string?
+  target_regions:
+    label: target regions
+    doc: |
+      Do stats in these regions only. Tab-delimited file chr,from,to, 1-based, inclusive. []
+    type: File?
+  sparse:
+    label: sparse
+    doc: |
+      Suppress outputting IS rows where there are no insertions.
+    type: boolean?
+  remove_overlaps:
+    label: remove overlaps
+    doc: |
+      Remove overlaps of paired-end reads from coverage and base count computations.
+    type: boolean?
+  cov_threshold:
+    label: cov threshold
+    doc: |
+      Only bases with coverage above this value will be included in the target percentage computation [0]
+    type: int?
+  threads:
+    label: threads
+    doc: |
+      Number of input/output compression threads to use in addition to main thread [0].
+    type: int?
+  # custom-qc
+  sample_id:
+    label: sample id
+    doc: |
+      Id of the input sample
+    type: string
+  output_json_filename:
+    label: output filename
+    doc: |
+      output file
+    type: string
+steps:
+  # samtools stats
+  samtools_stats_step:
+    label: samtools stats step
+    doc: samtools stats collects statistics from BAM files and outputs in a text format. 
+         The output can be visualized graphically using plot-bamstats.
+    in:
+      output_filename:
+        source: output_filename
+      input_bam:
+        source: input_bam
+      coverage:
+        source: coverage
+      remove_dups:
+        source: remove_dups
+      required_flag:
+        source: required_flag
+      filtering_flag:
+        source: filtering_flag
+      GC_depth:
+        source: GC_depth
+      insert_size:
+        source: insert_size
+      read_length:
+        source: read_length
+      most_inserts:
+        source: most_inserts
+      split_prefix:
+        source: split_prefix
+      trim_quality:
+        source: trim_quality
+      ref_seq:
+        source: ref_seq
+      split:
+        source: split
+      target_regions:
+        source: target_regions
+      sparse:
+        source: sparse
+      remove_overlaps:
+        source: remove_overlaps
+      cov_threshold:
+        source: cov_threshold
+      threads:
+        source: threads
+    out:
+      - id: output_file
+    run: ../../../tools/samtools-stats/1.13.0/samtools-stats__1.13.0.cwl
+    # custom QC
+  custom_stats_qc_step:
+    label: custom stats qc step
+    doc:
+      A tool to extract custom QC metrics from samtools stats output and convert to json format.
+    in:
+      sample_id:
+        source: sample_id
+      output_samtools_stats:
+        source: samtools_stats_step/output_file
+      output_json_filename:
+        source: output_json_filename
+    out:
+      - id: output_json
+    run: ../../../tools/custom-stats-qc/1.0.0/custom-stats-qc__1.0.0.cwl
+         
+outputs:
+  samtools_stats_output_txt:
+    label: samtools stats output txt
+    doc: |
+      Output file, of varying format depending on the command run
+    type: File
+    outputSource: samtools_stats_step/output_file
+  custom_stats_qc_output_json:
+    label: custom stats qc output json
+    doc: |
+      JSON output file containing custom metrics
+    type: File
+    outputSource: custom_stats_qc_step/output_json

--- a/workflows/ghif-qc/1.0.1/ghif-qc__1.0.1.cwl
+++ b/workflows/ghif-qc/1.0.1/ghif-qc__1.0.1.cwl
@@ -1,0 +1,218 @@
+cwlVersion: v1.1
+class: Workflow
+
+# Extensions
+$namespaces:
+    s: https://schema.org/
+$schemas:
+  - https://schema.org/version/latest/schemaorg-current-http.rdf
+
+# Metadata
+s:author:
+    class: s:Person
+    s:name: Sehrish Kanwal
+    s:email: sehrish.kanwal@umccr.org
+
+# ID/Docs
+id: ghif-qc--1.0.1
+label: ghif-qc v(1.0.1)
+doc: |
+    Documentation for ghif-qc v1.0.1
+
+requirements:
+    InlineJavascriptRequirement: {}
+    ScatterFeatureRequirement: {}
+    MultipleInputFeatureRequirement: {}
+    StepInputExpressionRequirement: {}
+
+inputs:
+  #samtools stats
+  output_filename:
+    label: output filename
+    doc: |
+      Redirects stdout
+    type: string
+  input_bam:
+    label: input BAM 
+    doc: |
+      The BAM file to gather statistics from
+    type: File
+    secondaryFiles:
+      - pattern: ".bai"
+        required: false
+  coverage:
+    label: coverage
+    doc: |
+      Set coverage distribution to the specified range (MIN, MAX, STEP all given as integers) [1,1000,1]
+    type: int[]?
+  remove_dups:
+    label: remove dups
+    doc: |
+      Exclude from statistics reads marked as duplicates
+    type: boolean?
+  required_flag:
+    label: required flag
+    doc: |
+      Required flag, 0 for unset. See also `samtools flags` [0]
+    type: int?
+  filtering_flag:
+    label: filtering flag
+    doc: |
+      iltering flag, 0 for unset. See also `samtools flags` [0]
+    type: int?
+  GC_depth:
+    label: GC depth 
+    doc: |
+      the size of GC-depth bins (decreasing bin size increases memory requirement) [2e4]
+    type: float?
+  insert_size:
+    label: insert size 
+    doc: |
+      Maximum insert size [8000]
+    type: int?
+  id:
+    label: id
+    doc: |
+      Include only listed read group or sample name []
+    type: string?
+  read_length:
+    label: read length 
+    doc: |
+      Include in the statistics only reads with the given read length [-1]
+    type: int?
+  most_inserts:
+    label: most inserts
+    doc: |
+      Report only the main part of inserts [0.99]
+    type: float?
+  split_prefix:
+    label: split prefix
+    doc: |
+      A path or string prefix to prepend to filenames output when creating categorised 
+      statistics files with -S/--split. [input filename]
+    type: string?
+  trim_quality:
+    label: trim quality
+    doc: |
+      The BWA trimming parameter [0]
+    type: int?
+  ref_seq:
+    label: ref seq
+    doc: |
+      Reference sequence (required for GC-depth and mismatches-per-cycle calculation). []
+    type: File?
+    secondaryFiles:
+      - pattern: ".fai"
+        required: true
+  split:
+    label: split
+    doc: |
+      In addition to the complete statistics, also output categorised statistics based on the tagged field TAG 
+      (e.g., use --split RG to split into read groups).
+    type: string?
+  target_regions:
+    label: target regions
+    doc: |
+      Do stats in these regions only. Tab-delimited file chr,from,to, 1-based, inclusive. []
+    type: File?
+  sparse:
+    label: sparse
+    doc: |
+      Suppress outputting IS rows where there are no insertions.
+    type: boolean?
+  remove_overlaps:
+    label: remove overlaps
+    doc: |
+      Remove overlaps of paired-end reads from coverage and base count computations.
+    type: boolean?
+  cov_threshold:
+    label: cov threshold
+    doc: |
+      Only bases with coverage above this value will be included in the target percentage computation [0]
+    type: int?
+  threads:
+    label: threads
+    doc: |
+      Number of input/output compression threads to use in addition to main thread [0].
+    type: int?
+  # custom-qc
+  output_json_filename:
+    label: output filename
+    doc: |
+      output file
+    type: string
+steps:
+  # samtools stats
+  samtools_stats_step:
+    label: samtools stats step
+    doc: samtools stats collects statistics from BAM files and outputs in a text format. 
+         The output can be visualized graphically using plot-bamstats.
+    in:
+      output_filename:
+        source: output_filename
+      input_bam:
+        source: input_bam
+      coverage:
+        source: coverage
+      remove_dups:
+        source: remove_dups
+      required_flag:
+        source: required_flag
+      filtering_flag:
+        source: filtering_flag
+      GC_depth:
+        source: GC_depth
+      insert_size:
+        source: insert_size
+      read_length:
+        source: read_length
+      most_inserts:
+        source: most_inserts
+      split_prefix:
+        source: split_prefix
+      trim_quality:
+        source: trim_quality
+      ref_seq:
+        source: ref_seq
+      split:
+        source: split
+      target_regions:
+        source: target_regions
+      sparse:
+        source: sparse
+      remove_overlaps:
+        source: remove_overlaps
+      cov_threshold:
+        source: cov_threshold
+      threads:
+        source: threads
+    out:
+      - id: output_file
+    run: ../../../tools/samtools-stats/1.13.0/samtools-stats__1.13.0.cwl
+    # custom QC
+  custom_stats_qc_step:
+    label: custom stats qc step
+    doc:
+      A tool to extract custom QC metrics from samtools stats output and convert to json format.
+    in:
+      output_samtools_stats:
+        source: samtools_stats_step/output_file
+      output_json_filename:
+        source: output_json_filename
+    out:
+      - id: output_json
+    run: ../../../tools/custom-stats-qc/1.0.1/custom-stats-qc__1.0.1.cwl
+         
+outputs:
+  samtools_stats_output_txt:
+    label: samtools stats output txt
+    doc: |
+      Output file, of varying format depending on the command run
+    type: File
+    outputSource: samtools_stats_step/output_file
+  custom_stats_qc_output_json:
+    label: custom stats qc output json
+    doc: |
+      JSON output file containing custom metrics
+    type: File
+    outputSource: custom_stats_qc_step/output_json

--- a/workflows/ghif-qc/1.0.1/ghif-qc__1.0.1.cwl
+++ b/workflows/ghif-qc/1.0.1/ghif-qc__1.0.1.cwl
@@ -136,6 +136,16 @@ inputs:
       Number of input/output compression threads to use in addition to main thread [0].
     type: int?
   # custom-qc
+  sample_id:
+    label: sample id
+    doc: |
+      Sample identity
+    type: string
+  sample_source:
+    label: sample source
+    doc: |
+      Sample original source
+    type: string
   output_json_filename:
     label: output filename
     doc: |
@@ -195,6 +205,10 @@ steps:
     doc:
       A tool to extract custom QC metrics from samtools stats output and convert to json format.
     in:
+      sample_id:
+        source: sample_id
+      sample_source:
+        source: sample_source
       output_samtools_stats:
         source: samtools_stats_step/output_file
       output_json_filename:


### PR DESCRIPTION
- created, tested, registered [samtools-stats tool](https://github.com/umccr/cwl-ica/blob/samtools-stats/tools/samtools-stats/1.13.0/samtools-stats__1.13.0.cwl)
- created, tested, registered [custom-stats tool](https://github.com/umccr/cwl-ica/blob/samtools-stats/tools/custom-stats-qc/1.0.0/custom-stats-qc__1.0.0.cwl)
- created workflow [definition](https://github.com/umccr/cwl-ica/blob/samtools-stats/workflows/ghif-qc/1.0.0/ghif-qc__1.0.0.cwl)

**WIP - testing workflow on ICA:**

Notes from today for discussion and future reference.

When testing workflow definiton on ICA `wfr.b0e6d07e4c7648af8b0aae390fedd8a9
` - step `custom_stats_qc_step` that calls `tools/custom-stats-qc/1.0.0/custom-stats-qc__1.0.0.cwl` errors out with:

```
$ gds-view --gds-path gds://wfr.b0e6d07e4c7648af8b0aae390fedd8a9/qc-ghif/logs/custom_stats_qc_step/try-1/task-stdouterr-0.log --to-stdout
+ jq -n --arg sm NA12878 '{sampleID: $sm}'
+ JSON_STRING='{
  "sampleID": "NA12878"
}'
+ echo ghifQC.json
ghifQC.json
+ echo '$JSON_STRING'
+ grep -h 'SN	average quality' /data/cwl-stage-dir/stg2253773b-4c0e-4071-af88-49ddb3528694/NA12878-test.txt
+ cut -f 3
+ avg_base_qual=29.5
+ jq -n --arg des 'average base quality' --arg src 'SN	average quality' --arg val 29.5 '{average_base_quality: {description: $des, source: $src, value: $val}}'
+ JSON_STRING='{
  "average_base_quality": {
    "description": "average base quality",
    "source": "SN\taverage quality",
    "value": "29.5"
  }
}'
+ echo '$JSON_STRING'
+ grep -h 'SN	bases mapped (cigar)' /data/cwl-stage-dir/stg2253773b-4c0e-4071-af88-49ddb3528694/NA12878-test.txt
+ cut -f 3
+ yield_mapped_bp=92677929585
+ jq -n --arg des 'yield mapped bp' --arg src 'SN	bases mapped (cigar)' --arg val 92677929585 '{yield_mapped_bp: {description: $des, source: $src, value: $val}}'
+ JSON_STRING='{
  "yield_mapped_bp": {
    "description": "yield mapped bp",
    "source": "SN\tbases mapped (cigar)",
    "value": "92677929585"
  }
}'
+ echo '$JSON_STRING'
+ grep -h 'SN	percentage of target genome with coverage > 20' /data/cwl-stage-dir/stg2253773b-4c0e-4071-af88-49ddb3528694/NA12878-test.txt
+ cut -f 3
+ pct_autosomes_20x=92.31
+ jq -n --arg des 'pct autosomes 20x' --arg src 'SN	percentage of target genome with coverage > 20' --arg val 92.31 '{pct_autosomes_20x: {description: $des, source: $src, value: $val}}'
+ JSON_STRING='{
  "pct_autosomes_20x": {
    "description": "pct autosomes 20x",
    "source": "SN\tpercentage of target genome with coverage > 20",
    "value": "92.31"
  }
}'
+ echo '$JSON_STRING'
+ grep -h 'SN	percentage of properly paired reads (%):' /data/cwl-stage-dir/stg2253773b-4c0e-4071-af88-49ddb3528694/NA12878-test.txt
+ cut -f3
+ pct_discordant_reads=98.3
+ awk '-vn1=$pct_discordant_reads' 'BEGIN { print (100 - n1) }'
+ pdr=100
+ jq -n --arg des 'pct discordant reads' --arg src 'SN	percentage of properly paired reads (%)' --arg val 98.3 '{pct_discordant_reads: {description: $des, source: $src, value: $val}}'
+ JSON_STRING='{
  "pct_discordant_reads": {
    "description": "pct discordant reads",
    "source": "SN\tpercentage of properly paired reads (%)",
    "value": "98.3"
  }
}'
+ echo '$JSON_STRING'
+ grep -h 'SN	insert size average:' /data/cwl-stage-dir/stg2253773b-4c0e-4071-af88-49ddb3528694/NA12878-test.txt
+ cut -f3
+ mean_insert_size=440.4
+ jq -n --arg des 'mean insert size' --arg src 'SN	insert size average' --arg val 440.4 '{mean_insert_size: {description: $des, source: $src, value: $val}}'
+ JSON_STRING='{
  "mean_insert_size": {
    "description": "mean insert size",
    "source": "SN\tinsert size average",
    "value": "440.4"
  }
}'
+ echo '$JSON_STRING'
+ grep -h 'SN	insert size standard deviation:' /data/cwl-stage-dir/stg2253773b-4c0e-4071-af88-49ddb3528694/NA12878-test.txt
+ cut -f3
+ insert_size_sd=98.3
+ jq -n --arg des 'insert size sd' --arg src 'SN	insert size standard deviation' --arg val 98.3 '{insert_size_sd: {description: $des, source: $src, value: $val}}'
+ JSON_STRING='{
  "insert_size_sd": {
    "description": "insert size sd",
    "source": "SN\tinsert size standard deviation",
    "value": "98.3"
  }
}'
+ echo '$JSON_STRING'
+ grep -h 'SN	reads mapped:' /data/cwl-stage-dir/stg2253773b-4c0e-4071-af88-49ddb3528694/NA12878-test.txt
+ cut -f3
+ RM=627813889
+ grep -h 'SN	reads MQ0:' /data/cwl-stage-dir/stg2253773b-4c0e-4071-af88-49ddb3528694/NA12878-test.txt
+ cut -f3
+ R0=30838716
+ grep -h 'SN	raw total sequences:' /data/cwl-stage-dir/stg2253773b-4c0e-4071-af88-49ddb3528694/NA12878-test.txt
+ cut -f3
+ RT=702833790
+ pct_mapped_reads=84
+ jq -n --arg des 'pct mapped reads' --arg src 'pct_mapped_reads = [(Mapped Reads - Reads MQ0) / Total Reads]' --arg val 84 '{pct_mapped_reads: {description: $des, source: $src, value: $val}}'
+ JSON_STRING='{
  "pct_mapped_reads": {
    "description": "pct mapped reads",
    "source": "pct_mapped_reads = [(Mapped Reads - Reads MQ0) / Total Reads]",
    "value": "84"
  }
}'
+ echo '$JSON_STRING'
+ jq . ghifQC.json
parse error: Invalid numeric literal at line 2, column 0
```

The task seems to be streaming the variable name `JSON_STRING` to intermediate output file `gds://wfr.b0e6d07e4c7648af8b0aae390fedd8a9/qc-ghif/steps/custom_stats_qc_step/try-1/ghifQC.json`, hence the `jq` parse error above.

```
$ gds-view --gds-path gds://wfr.b0e6d07e4c7648af8b0aae390fedd8a9/qc-ghif/steps/custom_stats_qc_step/try-1/ghifQC.json --to-stdout
$JSON_STRING
$JSON_STRING
$JSON_STRING
$JSON_STRING
$JSON_STRING
$JSON_STRING
$JSON_STRING
$JSON_STRING
```

When running this step independently `wfr.8430ff606baa4dca80feb4881dd74626`, the log indicates correct execution of inline bash script (notice the `echos` after `JSON_STRING` variable is created) and hence the correct intermediate output file is produced:

```
$ gds-view --gds-path gds://wfr.8430ff606baa4dca80feb4881dd74626/custom-qc/logs/main/try-1/task-stdouterr-0.log --to-stdout
+ jq -n --arg sm NA12878 '{sampleID: $sm}'
+ JSON_STRING='{
  "sampleID": "NA12878"
}'
+ echo postprocess.json
postprocess.json
+ echo '{' '"sampleID":' '"NA12878"' '}'
+ grep -h 'SN	average quality' /data/cwl-stage-dir/stg71173a94-4704-40e7-8e8b-4419bcae6387/samtools_stats.txt
+ cut -f 3
+ avg_base_qual=29.5
+ jq -n --arg des 'average base quality' --arg src 'SN	average quality' --arg val 29.5 '{average_base_quality: {description: $des, source: $src, value: $val}}'
+ JSON_STRING='{
  "average_base_quality": {
    "description": "average base quality",
    "source": "SN\taverage quality",
    "value": "29.5"
  }
}'
+ echo '{' '"average_base_quality":' '{' '"description":' '"average' base 'quality",' '"source":' '"SN\taverage' 'quality",' '"value":' '"29.5"' '}' '}'
+ grep -h 'SN	bases mapped (cigar)' /data/cwl-stage-dir/stg71173a94-4704-40e7-8e8b-4419bcae6387/samtools_stats.txt
+ cut -f 3
+ yield_mapped_bp=92677929585
+ jq -n --arg des 'yield mapped bp' --arg src 'SN	bases mapped (cigar)' --arg val 92677929585 '{yield_mapped_bp: {description: $des, source: $src, value: $val}}'
+ JSON_STRING='{
  "yield_mapped_bp": {
    "description": "yield mapped bp",
    "source": "SN\tbases mapped (cigar)",
    "value": "92677929585"
  }
}'
+ echo '{' '"yield_mapped_bp":' '{' '"description":' '"yield' mapped 'bp",' '"source":' '"SN\tbases' mapped '(cigar)",' '"value":' '"92677929585"' '}' '}'
+ grep -h 'SN	percentage of target genome with coverage > 20' /data/cwl-stage-dir/stg71173a94-4704-40e7-8e8b-4419bcae6387/samtools_stats.txt
+ cut -f 3
+ pct_autosomes_20x=92.31
+ jq -n --arg des 'pct autosomes 20x' --arg src 'SN	percentage of target genome with coverage > 20' --arg val 92.31 '{pct_autosomes_20x: {description: $des, source: $src, value: $val}}'
+ JSON_STRING='{
  "pct_autosomes_20x": {
    "description": "pct autosomes 20x",
    "source": "SN\tpercentage of target genome with coverage > 20",
    "value": "92.31"
  }
}'
+ echo '{' '"pct_autosomes_20x":' '{' '"description":' '"pct' autosomes '20x",' '"source":' '"SN\tpercentage' of target genome with coverage '>' '20",' '"value":' '"92.31"' '}' '}'
+ grep -h 'SN	percentage of properly paired reads (%):' /data/cwl-stage-dir/stg71173a94-4704-40e7-8e8b-4419bcae6387/samtools_stats.txt
+ cut -f3
+ pct_discordant_reads=98.3
+ awk '-vn1=98.3' 'BEGIN { print (100 - n1) }'
+ pdr=1.7
+ jq -n --arg des 'pct discordant reads' --arg src 'SN	percentage of properly paired reads (%)' --arg val 98.3 '{pct_discordant_reads: {description: $des, source: $src, value: $val}}'
+ JSON_STRING='{
  "pct_discordant_reads": {
    "description": "pct discordant reads",
    "source": "SN\tpercentage of properly paired reads (%)",
    "value": "98.3"
  }
}'
+ echo '{' '"pct_discordant_reads":' '{' '"description":' '"pct' discordant 'reads",' '"source":' '"SN\tpercentage' of properly paired reads '(%)",' '"value":' '"98.3"' '}' '}'
+ grep -h 'SN	insert size average:' /data/cwl-stage-dir/stg71173a94-4704-40e7-8e8b-4419bcae6387/samtools_stats.txt
+ cut -f3
+ mean_insert_size=440.4
+ jq -n --arg des 'mean insert size' --arg src 'SN	insert size average' --arg val 440.4 '{mean_insert_size: {description: $des, source: $src, value: $val}}'
+ JSON_STRING='{
  "mean_insert_size": {
    "description": "mean insert size",
    "source": "SN\tinsert size average",
    "value": "440.4"
  }
}'
+ echo '{' '"mean_insert_size":' '{' '"description":' '"mean' insert 'size",' '"source":' '"SN\tinsert' size 'average",' '"value":' '"440.4"' '}' '}'
+ grep -h 'SN	insert size standard deviation:' /data/cwl-stage-dir/stg71173a94-4704-40e7-8e8b-4419bcae6387/samtools_stats.txt
+ cut -f3
+ insert_size_sd=98.3
+ jq -n --arg des 'insert size sd' --arg src 'SN	insert size standard deviation' --arg val 98.3 '{insert_size_sd: {description: $des, source: $src, value: $val}}'
+ JSON_STRING='{
  "insert_size_sd": {
    "description": "insert size sd",
    "source": "SN\tinsert size standard deviation",
    "value": "98.3"
  }
}'
+ echo '{' '"insert_size_sd":' '{' '"description":' '"insert' size 'sd",' '"source":' '"SN\tinsert' size standard 'deviation",' '"value":' '"98.3"' '}' '}'
+ grep -h 'SN	reads mapped:' /data/cwl-stage-dir/stg71173a94-4704-40e7-8e8b-4419bcae6387/samtools_stats.txt
+ cut -f3
+ RM=627813889
+ grep -h 'SN	reads MQ0:' /data/cwl-stage-dir/stg71173a94-4704-40e7-8e8b-4419bcae6387/samtools_stats.txt
+ cut -f3
+ R0=30838716
+ grep -h 'SN	raw total sequences:' /data/cwl-stage-dir/stg71173a94-4704-40e7-8e8b-4419bcae6387/samtools_stats.txt
+ cut -f3
+ RT=702833790
+ pct_mapped_reads=84
+ jq -n --arg des 'pct mapped reads' --arg src 'pct_mapped_reads = [(Mapped Reads - Reads MQ0) / Total Reads]' --arg val 84 '{pct_mapped_reads: {description: $des, source: $src, value: $val}}'
+ JSON_STRING='{
  "pct_mapped_reads": {
    "description": "pct mapped reads",
    "source": "pct_mapped_reads = [(Mapped Reads - Reads MQ0) / Total Reads]",
    "value": "84"
  }
}'
+ echo '{' '"pct_mapped_reads":' '{' '"description":' '"pct' mapped 'reads",' '"source":' '"pct_mapped_reads' '=' '[(Mapped' Reads - Reads 'MQ0)' / Total 'Reads]",' '"value":' '"84"' '}' '}'
+ jq . postprocess.json
```

Expected intermediate output file:

```
$ gds-view --gds-path gds://wfr.8430ff606baa4dca80feb4881dd74626/custom-qc/steps/main/try-1/postprocess.json --to-stdout
{ "sampleID": "NA12878" }
{ "average_base_quality": { "description": "average base quality", "source": "SN\taverage quality", "value": "29.5" } }
{ "yield_mapped_bp": { "description": "yield mapped bp", "source": "SN\tbases mapped (cigar)", "value": "92677929585" } }
{ "pct_autosomes_20x": { "description": "pct autosomes 20x", "source": "SN\tpercentage of target genome with coverage > 20", "value": "92.31" } }
{ "pct_discordant_reads": { "description": "pct discordant reads", "source": "SN\tpercentage of properly paired reads (%)", "value": "98.3" } }
{ "mean_insert_size": { "description": "mean insert size", "source": "SN\tinsert size average", "value": "440.4" } }
{ "insert_size_sd": { "description": "insert size sd", "source": "SN\tinsert size standard deviation", "value": "98.3" } }
{ "pct_mapped_reads": { "description": "pct mapped reads", "source": "pct_mapped_reads = [(Mapped Reads - Reads MQ0) / Total Reads]", "value": "84" } }
```

