### PR TITLE
remove ilmn-tes namespace when not used

### DIFF
--- a/.github/catalogue/docs/expressions/create-predefined-mount-paths-and-umccrise-row-from-umccrise-schema/1.2.1--0/create-predefined-mount-paths-and-umccrise-row-from-umccrise-schema__1.2.1--0.md
+++ b/.github/catalogue/docs/expressions/create-predefined-mount-paths-and-umccrise-row-from-umccrise-schema/1.2.1--0/create-predefined-mount-paths-and-umccrise-row-from-umccrise-schema__1.2.1--0.md
@@ -16,7 +16,7 @@ create-predefined-mount-paths-and-umccrise-row-from-umccrise-schema 1.2.1--0 exp
 
   
 > ID: create-predefined-mount-paths-and-umccrise-row-from-umccrise-schema--1.2.1--0  
-> md5sum: 10900c8d1d5a71921ee4b5d23202287f
+> md5sum: 7f54fc29af33f53fe80c391bd1ee2c9c
 
 ### create-predefined-mount-paths-and-umccrise-row-from-umccrise-schema v(1.2.1--0) documentation
   

--- a/.github/catalogue/docs/expressions/create-predefined-mount-paths-and-umccrise-row-from-umccrise-schema/1.2.2--0/create-predefined-mount-paths-and-umccrise-row-from-umccrise-schema__1.2.2--0.md
+++ b/.github/catalogue/docs/expressions/create-predefined-mount-paths-and-umccrise-row-from-umccrise-schema/1.2.2--0/create-predefined-mount-paths-and-umccrise-row-from-umccrise-schema__1.2.2--0.md
@@ -16,7 +16,7 @@ create-predefined-mount-paths-and-umccrise-row-from-umccrise-schema 1.2.2--0 exp
 
   
 > ID: create-predefined-mount-paths-and-umccrise-row-from-umccrise-schema--1.2.2--0  
-> md5sum: 7caaf4d0d7e50f97eda0b1404c905cdb
+> md5sum: 518c4ac22827122cc82d37fc227f44e0
 
 ### create-predefined-mount-paths-and-umccrise-row-from-umccrise-schema v(1.2.2--0) documentation
   

--- a/.github/catalogue/docs/expressions/create-single-directory-from-directories-array/1.0.0/create-single-directory-from-directories-array__1.0.0.md
+++ b/.github/catalogue/docs/expressions/create-single-directory-from-directories-array/1.0.0/create-single-directory-from-directories-array__1.0.0.md
@@ -16,7 +16,7 @@ create-single-directory-from-directories-array 1.0.0 expression
 
   
 > ID: create-single-directory-from-directories-array--1.0.0  
-> md5sum: a60fd0524deeff885681f188c5192bc3
+> md5sum: c6b802120006853921fa2601ae5aafa0
 
 ### create-single-directory-from-directories-array v(1.0.0) documentation
   

--- a/.github/catalogue/docs/expressions/flatten-array-fastq-list/1.0.0/flatten-array-fastq-list__1.0.0.md
+++ b/.github/catalogue/docs/expressions/flatten-array-fastq-list/1.0.0/flatten-array-fastq-list__1.0.0.md
@@ -16,7 +16,7 @@ flatten-array-fastq-list 1.0.0 expression
 
   
 > ID: flatten-array-fastq-list-schema--1.0.0  
-> md5sum: 9c35f9205f9ce613b754f06f004b1de6
+> md5sum: b2f60519bb1706364b50aae21721356f
 
 ### flatten-array-fastq-list-schema v(1.0.0) documentation
   

--- a/.github/catalogue/docs/expressions/get-bam-file-from-directory/1.0.0/get-bam-file-from-directory__1.0.0.md
+++ b/.github/catalogue/docs/expressions/get-bam-file-from-directory/1.0.0/get-bam-file-from-directory__1.0.0.md
@@ -16,7 +16,7 @@ get-bam-file-from-directory 1.0.0 expression
 
   
 > ID: get-bam-file-from-directory--1.0.0  
-> md5sum: 6b3d67af802121ad5d6e5964b97e255c
+> md5sum: 24a56cf9eb2b4f7dc906e55d2a8906e7
 
 ### get-bam-file-from-directory v(1.0.0) documentation
   

--- a/.github/catalogue/docs/expressions/get-custom-output-dir-entry-for-tso500-post-processing/1.0.0/get-custom-output-dir-entry-for-tso500-post-processing__1.0.0.md
+++ b/.github/catalogue/docs/expressions/get-custom-output-dir-entry-for-tso500-post-processing/1.0.0/get-custom-output-dir-entry-for-tso500-post-processing__1.0.0.md
@@ -16,7 +16,7 @@ get-custom-output-dir-entry-for-tso500-post-processing 1.0.0 expression
 
   
 > ID: get-custom-output-dir-entry-for-tso500-post-processing--1.0.0  
-> md5sum: f5afc198579fa46d75969659d0680849
+> md5sum: 04e65d3150528001367f3639a2f43fc9
 
 ### get-custom-output-dir-entry-for-tso500-post-processing v(1.0.0) documentation
   
@@ -29,11 +29,6 @@ Create a custom-output-dir-entry 2.0.0 schema for the files and directories in t
 ## Related Links
   
 - [CWL File Path](../../../../../../expressions/get-custom-output-dir-entry-for-tso500-post-processing/1.0.0/get-custom-output-dir-entry-for-tso500-post-processing__1.0.0.cwl)  
-
-
-### Used By
-  
-- [tso500-ctdna-post-processing-pipeline 1.0.0](../../../workflows/tso500-ctdna-post-processing-pipeline/1.0.0/tso500-ctdna-post-processing-pipeline__1.0.0.md)  
 
   
 

--- a/.github/catalogue/docs/expressions/get-custom-output-dir-entry-for-tso500-post-processing/2.0.1/get-custom-output-dir-entry-for-tso500-post-processing__2.0.1.md
+++ b/.github/catalogue/docs/expressions/get-custom-output-dir-entry-for-tso500-post-processing/2.0.1/get-custom-output-dir-entry-for-tso500-post-processing__2.0.1.md
@@ -16,7 +16,7 @@ get-custom-output-dir-entry-for-tso500-post-processing 2.0.1 expression
 
   
 > ID: get-custom-output-dir-entry-for-tso500-post-processing--2.0.1  
-> md5sum: dc724d8a81377914442015e23d3da627
+> md5sum: 923f6796016b060cb73b572edc7e79a0
 
 ### get-custom-output-dir-entry-for-tso500-post-processing v(2.0.1) documentation
   

--- a/.github/catalogue/docs/expressions/get-custom-output-dir-entry-for-tso500-with-post-processing/2.0.1/get-custom-output-dir-entry-for-tso500-with-post-processing__2.0.1.md
+++ b/.github/catalogue/docs/expressions/get-custom-output-dir-entry-for-tso500-with-post-processing/2.0.1/get-custom-output-dir-entry-for-tso500-with-post-processing__2.0.1.md
@@ -16,7 +16,7 @@ get-custom-output-dir-entry-for-tso500-with-post-processing 2.0.1 expression
 
   
 > ID: get-custom-output-dir-entry-for-tso500-with-post-processing--2.0.1  
-> md5sum: dcecdce54ae1e4ff8e8206d77b166f41
+> md5sum: f4bb08524b73b86293e8319e68f1dc33
 
 ### get-custom-output-dir-entry-for-tso500-with-post-processing v(2.0.1) documentation
   

--- a/.github/catalogue/docs/expressions/get-samplesheet-midfix-regex/1.0.0/get-samplesheet-midfix-regex__1.0.0.md
+++ b/.github/catalogue/docs/expressions/get-samplesheet-midfix-regex/1.0.0/get-samplesheet-midfix-regex__1.0.0.md
@@ -16,7 +16,7 @@ get-samplesheet-midfix-regex 1.0.0 expression
 
   
 > ID: get-samplesheet-midfix-regex--1.0.0  
-> md5sum: 93d9dba10e7674e53a886ef28818c133
+> md5sum: 30f225562fad3598ba87998156f81469
 
 ### get-samplesheet-midfix-regex v(1.0.0) documentation
   

--- a/.github/catalogue/docs/expressions/parse-file/1.0.0/parse-file__1.0.0.md
+++ b/.github/catalogue/docs/expressions/parse-file/1.0.0/parse-file__1.0.0.md
@@ -16,7 +16,7 @@ parse-file 1.0.0 expression
 
   
 > ID: parse-file--1.0.0  
-> md5sum: 6b7a5626a907a0c97fd8b75e45760080
+> md5sum: 05ccd7c91a2b1f62877a3f2ad2542f74
 
 ### parse-file v(1.0.0) documentation
   

--- a/.github/catalogue/docs/expressions/parse-int-array/1.0.0/parse-int-array__1.0.0.md
+++ b/.github/catalogue/docs/expressions/parse-int-array/1.0.0/parse-int-array__1.0.0.md
@@ -16,7 +16,7 @@ parse-int-array 1.0.0 expression
 
   
 > ID: parse-int-array--1.0.0  
-> md5sum: 0cbe7e9f567a4b6e18c9f8af6fc79bce
+> md5sum: 3e84b4bb2fd52e184be3391937f11e5f
 
 ### parse-int-array v(1.0.0) documentation
   

--- a/.github/catalogue/docs/expressions/parse-int/1.0.0/parse-int__1.0.0.md
+++ b/.github/catalogue/docs/expressions/parse-int/1.0.0/parse-int__1.0.0.md
@@ -16,7 +16,7 @@ parse-int 1.0.0 expression
 
   
 > ID: parse-int--1.0.0  
-> md5sum: 54572449b52b935bb80007b224b0dd3e
+> md5sum: 3cf6b497f648c6ae0523309a17055f8e
 
 ### parse-int v(1.0.0) documentation
   

--- a/.github/catalogue/docs/tools/create-dummy-file/1.0.0/create-dummy-file__1.0.0.md
+++ b/.github/catalogue/docs/tools/create-dummy-file/1.0.0/create-dummy-file__1.0.0.md
@@ -17,7 +17,7 @@ create-dummy-file 1.0.0 tool
 
   
 > ID: create-dummy-file--1.0.0  
-> md5sum: e3489c0a1a03c088ce4b0865105b348d
+> md5sum: 3ec284b43a027d7fe2c22071e96e6c74
 
 ### create-dummy-file v(1.0.0) documentation
   

--- a/config/expression.yaml
+++ b/config/expression.yaml
@@ -18,35 +18,35 @@ expressions:
     versions:
       - name: 1.0.0
         path: 1.0.0/get-samplesheet-midfix-regex__1.0.0.cwl
-        md5sum: 93d9dba10e7674e53a886ef28818c133
+        md5sum: 30f225562fad3598ba87998156f81469
     categories: []
   - name: flatten-array-fastq-list
     path: flatten-array-fastq-list
     versions:
       - name: 1.0.0
         path: 1.0.0/flatten-array-fastq-list__1.0.0.cwl
-        md5sum: 9c35f9205f9ce613b754f06f004b1de6
+        md5sum: b2f60519bb1706364b50aae21721356f
     categories: []
   - name: parse-int-array
     path: parse-int-array
     versions:
       - name: 1.0.0
         path: 1.0.0/parse-int-array__1.0.0.cwl
-        md5sum: 0cbe7e9f567a4b6e18c9f8af6fc79bce
+        md5sum: 3e84b4bb2fd52e184be3391937f11e5f
     categories: []
   - name: parse-int
     path: parse-int
     versions:
       - name: 1.0.0
         path: 1.0.0/parse-int__1.0.0.cwl
-        md5sum: 54572449b52b935bb80007b224b0dd3e
+        md5sum: 3cf6b497f648c6ae0523309a17055f8e
     categories: []
   - name: parse-file
     path: parse-file
     versions:
       - name: 1.0.0
         path: 1.0.0/parse-file__1.0.0.cwl
-        md5sum: 6b7a5626a907a0c97fd8b75e45760080
+        md5sum: 05ccd7c91a2b1f62877a3f2ad2542f74
     categories: []
   - name: get-compressed-vcf-file-from-directory
     path: get-compressed-vcf-file-from-directory
@@ -60,39 +60,39 @@ expressions:
     versions:
       - name: 1.0.0
         path: 1.0.0/get-custom-output-dir-entry-for-tso500-post-processing__1.0.0.cwl
-        md5sum: f5afc198579fa46d75969659d0680849
+        md5sum: 04e65d3150528001367f3639a2f43fc9
       - name: 2.0.1
         path: 2.0.1/get-custom-output-dir-entry-for-tso500-post-processing__2.0.1.cwl
-        md5sum: dc724d8a81377914442015e23d3da627
+        md5sum: 923f6796016b060cb73b572edc7e79a0
     categories: []
   - name: get-bam-file-from-directory
     path: get-bam-file-from-directory
     versions:
       - name: 1.0.0
         path: 1.0.0/get-bam-file-from-directory__1.0.0.cwl
-        md5sum: 6b3d67af802121ad5d6e5964b97e255c
+        md5sum: 24a56cf9eb2b4f7dc906e55d2a8906e7
     categories: []
   - name: create-predefined-mount-paths-and-umccrise-row-from-umccrise-schema
     path: create-predefined-mount-paths-and-umccrise-row-from-umccrise-schema
     versions:
       - name: 1.2.1--0
         path: 1.2.1--0/create-predefined-mount-paths-and-umccrise-row-from-umccrise-schema__1.2.1--0.cwl
-        md5sum: 10900c8d1d5a71921ee4b5d23202287f
+        md5sum: 7f54fc29af33f53fe80c391bd1ee2c9c
       - name: 1.2.2--0
         path: 1.2.2--0/create-predefined-mount-paths-and-umccrise-row-from-umccrise-schema__1.2.2--0.cwl
-        md5sum: 7caaf4d0d7e50f97eda0b1404c905cdb
+        md5sum: 518c4ac22827122cc82d37fc227f44e0
     categories: []
   - name: get-custom-output-dir-entry-for-tso500-with-post-processing
     path: get-custom-output-dir-entry-for-tso500-with-post-processing
     versions:
       - name: 2.0.1
         path: 2.0.1/get-custom-output-dir-entry-for-tso500-with-post-processing__2.0.1.cwl
-        md5sum: dcecdce54ae1e4ff8e8206d77b166f41
+        md5sum: f4bb08524b73b86293e8319e68f1dc33
     categories: []
   - name: create-single-directory-from-directories-array
     path: create-single-directory-from-directories-array
     versions:
       - name: 1.0.0
         path: 1.0.0/create-single-directory-from-directories-array__1.0.0.cwl
-        md5sum: a60fd0524deeff885681f188c5192bc3
+        md5sum: c6b802120006853921fa2601ae5aafa0
     categories: []

--- a/config/project.yaml
+++ b/config/project.yaml
@@ -435,7 +435,7 @@ projects:
           - name: 2.0.183
             path: 2.0.183/bamtofastq__2.0.183.cwl
             ica_workflow_version_name: 2.0.183
-            modification_time: 2022-06-09T03:00:48UTC
+            modification_time: 2022-09-01T03:31:02UTC
             run_instances: []
       - name: mosdepth
         path: mosdepth

--- a/config/tool.yaml
+++ b/config/tool.yaml
@@ -136,7 +136,7 @@ tools:
     versions:
       - name: 1.0.0
         path: 1.0.0/create-dummy-file__1.0.0.cwl
-        md5sum: e3489c0a1a03c088ce4b0865105b348d
+        md5sum: 3ec284b43a027d7fe2c22071e96e6c74
     categories: []
   - name: multiqc-interop
     path: multiqc-interop

--- a/expressions/assert-true/1.0.0/assert-true__1.0.0.cwl
+++ b/expressions/assert-true/1.0.0/assert-true__1.0.0.cwl
@@ -4,7 +4,6 @@ class: ExpressionTool
 # Extensions
 $namespaces:
     s: https://schema.org/
-    ilmn-tes: http://platform.illumina.com/rdf/ica/
 $schemas:
   - https://schema.org/version/latest/schemaorg-current-http.rdf
 

--- a/expressions/create-predefined-mount-paths-and-umccrise-row-from-umccrise-schema/1.2.1--0/create-predefined-mount-paths-and-umccrise-row-from-umccrise-schema__1.2.1--0.cwl
+++ b/expressions/create-predefined-mount-paths-and-umccrise-row-from-umccrise-schema/1.2.1--0/create-predefined-mount-paths-and-umccrise-row-from-umccrise-schema__1.2.1--0.cwl
@@ -4,7 +4,6 @@ class: ExpressionTool
 # Extensions
 $namespaces:
     s: https://schema.org/
-    ilmn-tes: http://platform.illumina.com/rdf/ica/
 $schemas:
   - https://schema.org/version/latest/schemaorg-current-http.rdf
 

--- a/expressions/create-predefined-mount-paths-and-umccrise-row-from-umccrise-schema/1.2.2--0/create-predefined-mount-paths-and-umccrise-row-from-umccrise-schema__1.2.2--0.cwl
+++ b/expressions/create-predefined-mount-paths-and-umccrise-row-from-umccrise-schema/1.2.2--0/create-predefined-mount-paths-and-umccrise-row-from-umccrise-schema__1.2.2--0.cwl
@@ -4,7 +4,6 @@ class: ExpressionTool
 # Extensions
 $namespaces:
     s: https://schema.org/
-    ilmn-tes: http://platform.illumina.com/rdf/ica/
 $schemas:
   - https://schema.org/version/latest/schemaorg-current-http.rdf
 

--- a/expressions/create-single-directory-from-directories-array/1.0.0/create-single-directory-from-directories-array__1.0.0.cwl
+++ b/expressions/create-single-directory-from-directories-array/1.0.0/create-single-directory-from-directories-array__1.0.0.cwl
@@ -4,7 +4,6 @@ class: ExpressionTool
 # Extensions
 $namespaces:
     s: https://schema.org/
-    ilmn-tes: http://platform.illumina.com/rdf/ica/
 $schemas:
   - https://schema.org/version/latest/schemaorg-current-http.rdf
 

--- a/expressions/ensure-all-samples-have-passed-all-tso500-ctdna-steps/1.0.0/ensure-all-samples-have-passed-all-tso500-ctdna-steps__1.0.0.cwl
+++ b/expressions/ensure-all-samples-have-passed-all-tso500-ctdna-steps/1.0.0/ensure-all-samples-have-passed-all-tso500-ctdna-steps__1.0.0.cwl
@@ -4,7 +4,6 @@ class: ExpressionTool
 # Extensions
 $namespaces:
     s: https://schema.org/
-    ilmn-tes: http://platform.illumina.com/rdf/ica/
 $schemas:
   - https://schema.org/version/latest/schemaorg-current-http.rdf
 

--- a/expressions/flatten-array-fastq-list/1.0.0/flatten-array-fastq-list__1.0.0.cwl
+++ b/expressions/flatten-array-fastq-list/1.0.0/flatten-array-fastq-list__1.0.0.cwl
@@ -4,7 +4,6 @@ class: ExpressionTool
 # Extensions
 $namespaces:
     s: https://schema.org/
-    ilmn-tes: http://platform.illumina.com/rdf/ica/
 $schemas:
   - https://schema.org/version/latest/schemaorg-current-http.rdf
 

--- a/expressions/get-attr-from-tso500-sample-object/1.0.0/get-attr-from-tso500-sample-object__1.0.0.cwl
+++ b/expressions/get-attr-from-tso500-sample-object/1.0.0/get-attr-from-tso500-sample-object__1.0.0.cwl
@@ -4,7 +4,6 @@ class: ExpressionTool
 # Extensions
 $namespaces:
     s: https://schema.org/
-    ilmn-tes: http://platform.illumina.com/rdf/ica/
 $schemas:
   - https://schema.org/version/latest/schemaorg-current-http.rdf
 

--- a/expressions/get-bam-file-from-directory/1.0.0/get-bam-file-from-directory__1.0.0.cwl
+++ b/expressions/get-bam-file-from-directory/1.0.0/get-bam-file-from-directory__1.0.0.cwl
@@ -4,7 +4,6 @@ class: ExpressionTool
 # Extensions
 $namespaces:
     s: https://schema.org/
-    ilmn-tes: http://platform.illumina.com/rdf/ica/
 $schemas:
   - https://schema.org/version/latest/schemaorg-current-http.rdf
 

--- a/expressions/get-bam-file-from-directory/1.0.1/get-bam-file-from-directory__1.0.1.cwl
+++ b/expressions/get-bam-file-from-directory/1.0.1/get-bam-file-from-directory__1.0.1.cwl
@@ -4,7 +4,6 @@ class: ExpressionTool
 # Extensions
 $namespaces:
     s: https://schema.org/
-    ilmn-tes: http://platform.illumina.com/rdf/ica/
 $schemas:
   - https://schema.org/version/latest/schemaorg-current-http.rdf
 

--- a/expressions/get-custom-output-dir-entry-for-tso500-post-processing/1.0.0/get-custom-output-dir-entry-for-tso500-post-processing__1.0.0.cwl
+++ b/expressions/get-custom-output-dir-entry-for-tso500-post-processing/1.0.0/get-custom-output-dir-entry-for-tso500-post-processing__1.0.0.cwl
@@ -4,7 +4,6 @@ class: ExpressionTool
 # Extensions
 $namespaces:
     s: https://schema.org/
-    ilmn-tes: http://platform.illumina.com/rdf/ica/
 $schemas:
   - https://schema.org/version/latest/schemaorg-current-http.rdf
 

--- a/expressions/get-custom-output-dir-entry-for-tso500-post-processing/2.0.1/get-custom-output-dir-entry-for-tso500-post-processing__2.0.1.cwl
+++ b/expressions/get-custom-output-dir-entry-for-tso500-post-processing/2.0.1/get-custom-output-dir-entry-for-tso500-post-processing__2.0.1.cwl
@@ -4,7 +4,6 @@ class: ExpressionTool
 # Extensions
 $namespaces:
     s: https://schema.org/
-    ilmn-tes: http://platform.illumina.com/rdf/ica/
 $schemas:
   - https://schema.org/version/latest/schemaorg-current-http.rdf
 

--- a/expressions/get-custom-output-dir-entry-for-tso500-with-post-processing/1.0.0/get-custom-output-dir-entry-for-tso500-with-post-processing__1.0.0.cwl
+++ b/expressions/get-custom-output-dir-entry-for-tso500-with-post-processing/1.0.0/get-custom-output-dir-entry-for-tso500-with-post-processing__1.0.0.cwl
@@ -4,7 +4,6 @@ class: ExpressionTool
 # Extensions
 $namespaces:
     s: https://schema.org/
-    ilmn-tes: http://platform.illumina.com/rdf/ica/
 $schemas:
   - https://schema.org/version/latest/schemaorg-current-http.rdf
 

--- a/expressions/get-custom-output-dir-entry-for-tso500-with-post-processing/2.0.1/get-custom-output-dir-entry-for-tso500-with-post-processing__2.0.1.cwl
+++ b/expressions/get-custom-output-dir-entry-for-tso500-with-post-processing/2.0.1/get-custom-output-dir-entry-for-tso500-with-post-processing__2.0.1.cwl
@@ -4,7 +4,6 @@ class: ExpressionTool
 # Extensions
 $namespaces:
     s: https://schema.org/
-    ilmn-tes: http://platform.illumina.com/rdf/ica/
 $schemas:
   - https://schema.org/version/latest/schemaorg-current-http.rdf
 

--- a/expressions/get-file-from-directory-with-regex/1.0.0/get-file-from-directory-with-regex__1.0.0.cwl
+++ b/expressions/get-file-from-directory-with-regex/1.0.0/get-file-from-directory-with-regex__1.0.0.cwl
@@ -4,7 +4,6 @@ class: ExpressionTool
 # Extensions
 $namespaces:
     s: https://schema.org/
-    ilmn-tes: http://platform.illumina.com/rdf/ica/
 $schemas:
   - https://schema.org/version/latest/schemaorg-current-http.rdf
 

--- a/expressions/get-file-from-directory/1.0.0/get-file-from-directory__1.0.0.cwl
+++ b/expressions/get-file-from-directory/1.0.0/get-file-from-directory__1.0.0.cwl
@@ -4,7 +4,6 @@ class: ExpressionTool
 # Extensions
 $namespaces:
     s: https://schema.org/
-    ilmn-tes: http://platform.illumina.com/rdf/ica/
 $schemas:
   - https://schema.org/version/latest/schemaorg-current-http.rdf
 

--- a/expressions/get-files-from-directory/1.0.0/get-files-from-directory__1.0.0.cwl
+++ b/expressions/get-files-from-directory/1.0.0/get-files-from-directory__1.0.0.cwl
@@ -4,7 +4,6 @@ class: ExpressionTool
 # Extensions
 $namespaces:
     s: https://schema.org/
-    ilmn-tes: http://platform.illumina.com/rdf/ica/
 $schemas:
   - https://schema.org/version/latest/schemaorg-current-http.rdf
 

--- a/expressions/get-samplesheet-midfix-regex/1.0.0/get-samplesheet-midfix-regex__1.0.0.cwl
+++ b/expressions/get-samplesheet-midfix-regex/1.0.0/get-samplesheet-midfix-regex__1.0.0.cwl
@@ -4,7 +4,6 @@ class: ExpressionTool
 # Extensions
 $namespaces:
     s: https://schema.org/
-    ilmn-tes: http://platform.illumina.com/rdf/ica/
 $schemas:
   - https://schema.org/version/latest/schemaorg-current-http.rdf
 

--- a/expressions/get-subdirectory-from-directory/1.0.0/get-subdirectory-from-directory__1.0.0.cwl
+++ b/expressions/get-subdirectory-from-directory/1.0.0/get-subdirectory-from-directory__1.0.0.cwl
@@ -4,7 +4,6 @@ class: ExpressionTool
 # Extensions
 $namespaces:
     s: https://schema.org/
-    ilmn-tes: http://platform.illumina.com/rdf/ica/
 $schemas:
   - https://schema.org/version/latest/schemaorg-current-http.rdf
 

--- a/expressions/get-tso500-outputs-per-sample/1.0.0/get-tso500-outputs-per-sample__1.0.0.cwl
+++ b/expressions/get-tso500-outputs-per-sample/1.0.0/get-tso500-outputs-per-sample__1.0.0.cwl
@@ -4,7 +4,6 @@ class: ExpressionTool
 # Extensions
 $namespaces:
     s: https://schema.org/
-    ilmn-tes: http://platform.illumina.com/rdf/ica/
 $schemas:
   - https://schema.org/version/latest/schemaorg-current-http.rdf
 

--- a/expressions/parse-file/1.0.0/parse-file__1.0.0.cwl
+++ b/expressions/parse-file/1.0.0/parse-file__1.0.0.cwl
@@ -4,7 +4,6 @@ class: ExpressionTool
 # Extensions
 $namespaces:
     s: https://schema.org/
-    ilmn-tes: http://platform.illumina.com/rdf/ica/
 $schemas:
   - https://schema.org/version/latest/schemaorg-current-http.rdf
 

--- a/expressions/parse-int-array/1.0.0/parse-int-array__1.0.0.cwl
+++ b/expressions/parse-int-array/1.0.0/parse-int-array__1.0.0.cwl
@@ -4,7 +4,6 @@ class: ExpressionTool
 # Extensions
 $namespaces:
     s: https://schema.org/
-    ilmn-tes: http://platform.illumina.com/rdf/ica/
 $schemas:
   - https://schema.org/version/latest/schemaorg-current-http.rdf
 

--- a/expressions/parse-int/1.0.0/parse-int__1.0.0.cwl
+++ b/expressions/parse-int/1.0.0/parse-int__1.0.0.cwl
@@ -4,7 +4,6 @@ class: ExpressionTool
 # Extensions
 $namespaces:
     s: https://schema.org/
-    ilmn-tes: http://platform.illumina.com/rdf/ica/
 $schemas:
   - https://schema.org/version/latest/schemaorg-current-http.rdf
 

--- a/expressions/parse-string-array/1.0.0/parse-string-array__1.0.0.cwl
+++ b/expressions/parse-string-array/1.0.0/parse-string-array__1.0.0.cwl
@@ -4,7 +4,6 @@ class: ExpressionTool
 # Extensions
 $namespaces:
     s: https://schema.org/
-    ilmn-tes: http://platform.illumina.com/rdf/ica/
 $schemas:
   - https://schema.org/version/latest/schemaorg-current-http.rdf
 

--- a/expressions/parse-string/1.0.0/parse-string__1.0.0.cwl
+++ b/expressions/parse-string/1.0.0/parse-string__1.0.0.cwl
@@ -4,7 +4,6 @@ class: ExpressionTool
 # Extensions
 $namespaces:
     s: https://schema.org/
-    ilmn-tes: http://platform.illumina.com/rdf/ica/
 $schemas:
   - https://schema.org/version/latest/schemaorg-current-http.rdf
 

--- a/expressions/validate-dsdm-json/1.0.0/validate-dsdm-json__1.0.0.cwl
+++ b/expressions/validate-dsdm-json/1.0.0/validate-dsdm-json__1.0.0.cwl
@@ -4,7 +4,6 @@ class: ExpressionTool
 # Extensions
 $namespaces:
     s: https://schema.org/
-    ilmn-tes: http://platform.illumina.com/rdf/ica/
 $schemas:
   - https://schema.org/version/latest/schemaorg-current-http.rdf
 

--- a/src/classes/cwl_expression.py
+++ b/src/classes/cwl_expression.py
@@ -152,7 +152,6 @@ class CWLExpression(CWL):
                 schemas=["https://schema.org/version/latest/schemaorg-current-http.rdf"],
                 namespaces={
                     "s": "https://schema.org/",
-                    "ilmn-tes": "http://platform.illumina.com/rdf/ica/"
                 }
             )
         )

--- a/tools/create-dummy-file/1.0.0/create-dummy-file__1.0.0.cwl
+++ b/tools/create-dummy-file/1.0.0/create-dummy-file__1.0.0.cwl
@@ -4,7 +4,6 @@ class: CommandLineTool
 # Extensions
 $namespaces:
     s: https://schema.org/
-    ilmn-tes: http://platform.illumina.com/rdf/ica/
 $schemas:
   - https://schema.org/version/latest/schemaorg-current-http.rdf
 

--- a/tools/create-dummy-file/1.0.0/create-dummy-file__1.0.0.cwl
+++ b/tools/create-dummy-file/1.0.0/create-dummy-file__1.0.0.cwl
@@ -4,6 +4,7 @@ class: CommandLineTool
 # Extensions
 $namespaces:
     s: https://schema.org/
+    ilmn-tes: http://platform.illumina.com/rdf/ica/
 $schemas:
   - https://schema.org/version/latest/schemaorg-current-http.rdf
 
@@ -22,6 +23,10 @@ doc: |
 
 hints:
     ResourceRequirement:
+      ilmn-tes:resources:
+        tier: standard
+        type: standard
+        size: small
       coresMin: 2
       ramMin: 4000
     DockerRequirement:


### PR DESCRIPTION
## Summary
Removed unnecessary ilmn-tes schema namespace in expressions.
Part B of superseding #115

## Commits
1eb0e04d7fd1d76ef4002e6e70899a67c60ff652 @mr-c Removed ilmn-tes namespace when not used 
6d07a57669cde3196f24d14d11aa1a4f3b7a0e3f @alexiswl updated dummy file tool to specify ilmn-tes resources that had not been added.