### PR TITLE
Add umccrise v2.2 tool

### DIFF
--- a/.github/catalogue/docs/tools/umccrise/2.2.0--0/umccrise__2.2.0--0.md
+++ b/.github/catalogue/docs/tools/umccrise/2.2.0--0/umccrise__2.2.0--0.md
@@ -1,0 +1,181 @@
+
+umccrise 2.2.0--0 tool
+======================
+
+## Table of Contents
+  
+- [Overview](#umccrise-v220--0-overview)  
+- [Links](#related-links)  
+- [Inputs](#umccrise-v220--0-inputs)  
+- [Outputs](#umccrise-v220--0-outputs)  
+- [ICA](#ica)  
+
+
+## umccrise v(2.2.0--0) Overview
+
+
+
+  
+> ID: umccrise--2.2.0--0  
+> md5sum: 29bd6aa6205e7b68d9395771a6e62a9c
+
+### umccrise v(2.2.0--0) documentation
+  
+Documentation for umccrise v2.2.0--0
+
+### Categories
+  
+
+
+## Related Links
+  
+- [CWL File Path](../../../../../../tools/umccrise/2.2.0--0/umccrise__2.2.0--0.cwl)  
+
+  
+
+
+## umccrise v(2.2.0--0) Inputs
+
+### dragen germline directory
+
+
+
+  
+> ID: dragen_germline_directory
+  
+**Optional:** `False`  
+**Type:** `Directory`  
+**Docs:**  
+The dragen germline directory
+
+
+### dragen normal id
+
+
+
+  
+> ID: dragen_normal_id
+  
+**Optional:** `False`  
+**Type:** `string`  
+**Docs:**  
+The name of the dragen normal sample
+
+
+### dragen somatic directory
+
+
+
+  
+> ID: dragen_somatic_directory
+  
+**Optional:** `False`  
+**Type:** `Directory`  
+**Docs:**  
+The dragen somatic directory
+
+
+### dragen tumor id
+
+
+
+  
+> ID: dragen_tumor_id
+  
+**Optional:** `False`  
+**Type:** `string`  
+**Docs:**  
+The name of the dragen tumor sample
+
+
+### genomes tar
+
+
+
+  
+> ID: genomes_tar
+  
+**Optional:** `False`  
+**Type:** `File`  
+**Docs:**  
+The reference umccrise tarball
+
+
+### output directory name
+
+
+
+  
+> ID: output_directory_name
+  
+**Optional:** `False`  
+**Type:** `string`  
+**Docs:**  
+The name of the output directory
+
+
+### subject identifier
+
+
+
+  
+> ID: subject_identifier
+  
+**Optional:** `False`  
+**Type:** `string`  
+**Docs:**  
+The subject ID (used to name output files)
+
+
+### threads
+
+
+
+  
+> ID: threads
+  
+**Optional:** `True`  
+**Type:** `int`  
+**Docs:**  
+Number of threads to use
+
+  
+
+
+## umccrise v(2.2.0--0) Outputs
+
+### output directory
+
+
+
+  
+> ID: umccrise--2.2.0--0/output_directory  
+
+  
+**Optional:** `False`  
+**Output Type:** `Directory`  
+**Docs:**  
+The output directory containing the umccrise data
+  
+
+  
+
+
+## ICA
+
+### ToC
+  
+- [development_workflows](#project-development_workflows)  
+
+
+### Project: development_workflows
+
+
+> wfl id: wfl.af61d2b172e84cbfa85eaf184226db8b  
+
+  
+**workflow name:** umccrise_dev-wf  
+**wfl version name:** 2.2.0--0  
+
+  
+

--- a/.github/catalogue/docs/tools/umccrise/2.2.0--0/umccrise__2.2.0--0.md
+++ b/.github/catalogue/docs/tools/umccrise/2.2.0--0/umccrise__2.2.0--0.md
@@ -166,6 +166,7 @@ The output directory containing the umccrise data
 ### ToC
   
 - [development_workflows](#project-development_workflows)  
+- [production_workflows](#project-production_workflows)  
 
 
 ### Project: development_workflows
@@ -176,6 +177,16 @@ The output directory containing the umccrise data
   
 **workflow name:** umccrise_dev-wf  
 **wfl version name:** 2.2.0--0  
+
+
+### Project: production_workflows
+
+
+> wfl id: wfl.714e9172f3674023b210ccc7c47db05a  
+
+  
+**workflow name:** umccrise_prod-wf  
+**wfl version name:** 2.2.0--0--1ecf63c  
 
   
 

--- a/.github/catalogue/docs/tools/umccrise/2.2.1--0/umccrise__2.2.1--0.md
+++ b/.github/catalogue/docs/tools/umccrise/2.2.1--0/umccrise__2.2.1--0.md
@@ -1,0 +1,181 @@
+
+umccrise 2.2.1--0 tool
+======================
+
+## Table of Contents
+  
+- [Overview](#umccrise-v221--0-overview)  
+- [Links](#related-links)  
+- [Inputs](#umccrise-v221--0-inputs)  
+- [Outputs](#umccrise-v221--0-outputs)  
+- [ICA](#ica)  
+
+
+## umccrise v(2.2.1--0) Overview
+
+
+
+  
+> ID: umccrise--2.2.1--0  
+> md5sum: 63eddbafc4f86e24d5a9092b18a3ccdb
+
+### umccrise v(2.2.1--0) documentation
+  
+Documentation for umccrise v2.2.1--0
+
+### Categories
+  
+
+
+## Related Links
+  
+- [CWL File Path](../../../../../../tools/umccrise/2.2.1--0/umccrise__2.2.1--0.cwl)  
+
+  
+
+
+## umccrise v(2.2.1--0) Inputs
+
+### dragen germline directory
+
+
+
+  
+> ID: dragen_germline_directory
+  
+**Optional:** `False`  
+**Type:** `Directory`  
+**Docs:**  
+The dragen germline directory
+
+
+### dragen normal id
+
+
+
+  
+> ID: dragen_normal_id
+  
+**Optional:** `False`  
+**Type:** `string`  
+**Docs:**  
+The name of the dragen normal sample
+
+
+### dragen somatic directory
+
+
+
+  
+> ID: dragen_somatic_directory
+  
+**Optional:** `False`  
+**Type:** `Directory`  
+**Docs:**  
+The dragen somatic directory
+
+
+### dragen tumor id
+
+
+
+  
+> ID: dragen_tumor_id
+  
+**Optional:** `False`  
+**Type:** `string`  
+**Docs:**  
+The name of the dragen tumor sample
+
+
+### genomes tar
+
+
+
+  
+> ID: genomes_tar
+  
+**Optional:** `False`  
+**Type:** `File`  
+**Docs:**  
+The reference umccrise tarball
+
+
+### output directory name
+
+
+
+  
+> ID: output_directory_name
+  
+**Optional:** `False`  
+**Type:** `string`  
+**Docs:**  
+The name of the output directory
+
+
+### subject identifier
+
+
+
+  
+> ID: subject_identifier
+  
+**Optional:** `False`  
+**Type:** `string`  
+**Docs:**  
+The subject ID (used to name output files)
+
+
+### threads
+
+
+
+  
+> ID: threads
+  
+**Optional:** `True`  
+**Type:** `int`  
+**Docs:**  
+Number of threads to use
+
+  
+
+
+## umccrise v(2.2.1--0) Outputs
+
+### output directory
+
+
+
+  
+> ID: umccrise--2.2.1--0/output_directory  
+
+  
+**Optional:** `False`  
+**Output Type:** `Directory`  
+**Docs:**  
+The output directory containing the umccrise data
+  
+
+  
+
+
+## ICA
+
+### ToC
+  
+- [development_workflows](#project-development_workflows)  
+
+
+### Project: development_workflows
+
+
+> wfl id: wfl.af61d2b172e84cbfa85eaf184226db8b  
+
+  
+**workflow name:** umccrise_dev-wf  
+**wfl version name:** 2.2.1--0  
+
+  
+

--- a/.github/catalogue/docs/tools/umccrise/2.2.1--0/umccrise__2.2.1--0.md
+++ b/.github/catalogue/docs/tools/umccrise/2.2.1--0/umccrise__2.2.1--0.md
@@ -166,6 +166,7 @@ The output directory containing the umccrise data
 ### ToC
   
 - [development_workflows](#project-development_workflows)  
+- [production_workflows](#project-production_workflows)  
 
 
 ### Project: development_workflows
@@ -176,6 +177,16 @@ The output directory containing the umccrise data
   
 **workflow name:** umccrise_dev-wf  
 **wfl version name:** 2.2.1--0  
+
+
+### Project: production_workflows
+
+
+> wfl id: wfl.714e9172f3674023b210ccc7c47db05a  
+
+  
+**workflow name:** umccrise_prod-wf  
+**wfl version name:** 2.2.1--0--1ecf63c  
 
   
 

--- a/config/project.yaml
+++ b/config/project.yaml
@@ -292,6 +292,16 @@ projects:
             ica_workflow_version_name: 2.1.1--0
             modification_time: 2022-10-11T06:35:52UTC
             run_instances: []
+          - name: 2.2.0--0
+            path: 2.2.0--0/umccrise__2.2.0--0.cwl
+            ica_workflow_version_name: 2.2.0--0
+            modification_time: 2022-10-19T09:32:23UTC
+            run_instances: []
+          - name: 2.2.1--0
+            path: 2.2.1--0/umccrise__2.2.1--0.cwl
+            ica_workflow_version_name: 2.2.1--0
+            modification_time: 2022-10-19T09:43:17UTC
+            run_instances: []
       - name: dragen-somatic
         path: dragen-somatic
         ica_workflow_name: dragen-somatic_dev-wf

--- a/config/project.yaml
+++ b/config/project.yaml
@@ -863,13 +863,13 @@ projects:
         versions:
           - name: 2.2.0--0
             path: 2.2.0--0/umccrise__2.2.0--0.cwl
-            ica_workflow_version_name: 2.2.0--0--__GIT_COMMIT_ID__
-            modification_time:
+            ica_workflow_version_name: 2.2.0--0--1ecf63c
+            modification_time: 2022-10-19T11:46:19UTC
             run_instances: []
           - name: 2.2.1--0
             path: 2.2.1--0/umccrise__2.2.1--0.cwl
-            ica_workflow_version_name: 2.2.1--0--__GIT_COMMIT_ID__
-            modification_time:
+            ica_workflow_version_name: 2.2.1--0--1ecf63c
+            modification_time: 2022-10-19T11:46:23UTC
             run_instances: []
     workflows:
       - name: tso500-ctdna

--- a/config/project.yaml
+++ b/config/project.yaml
@@ -856,6 +856,21 @@ projects:
             ica_workflow_version_name: 0.4.4--984c780
             modification_time: 2022-10-11T06:36:35UTC
             run_instances: []
+      - name: umccrise
+        path: umccrise
+        ica_workflow_name: umccrise_prod-wf
+        ica_workflow_id: wfl.714e9172f3674023b210ccc7c47db05a
+        versions:
+          - name: 2.2.0--0
+            path: 2.2.0--0/umccrise__2.2.0--0.cwl
+            ica_workflow_version_name: 2.2.0--0--__GIT_COMMIT_ID__
+            modification_time:
+            run_instances: []
+          - name: 2.2.1--0
+            path: 2.2.1--0/umccrise__2.2.1--0.cwl
+            ica_workflow_version_name: 2.2.1--0--__GIT_COMMIT_ID__
+            modification_time:
+            run_instances: []
     workflows:
       - name: tso500-ctdna
         path: tso500-ctdna

--- a/config/tool.yaml
+++ b/config/tool.yaml
@@ -338,10 +338,10 @@ tools:
         md5sum: 32cf72666f2c86a481277dc6477fab2c
       - name: 2.2.0--0
         path: 2.2.0--0/umccrise__2.2.0--0.cwl
-        md5sum: 5c8e63abb96cd167d54a800d6a9b373f
+        md5sum: 29bd6aa6205e7b68d9395771a6e62a9c
       - name: 2.2.1--0
         path: 2.2.1--0/umccrise__2.2.1--0.cwl
-        md5sum: c94a4d335268a2dd3778b054a6bf5f06
+        md5sum: 63eddbafc4f86e24d5a9092b18a3ccdb
     categories: []
   - name: custom-create-umccr-dragen-refdata-tarball-from-illumina-tar
     path: custom-create-umccr-dragen-refdata-tarball-from-illumina-tar

--- a/config/tool.yaml
+++ b/config/tool.yaml
@@ -336,12 +336,12 @@ tools:
       - name: 2.1.1--0
         path: 2.1.1--0/umccrise__2.1.1--0.cwl
         md5sum: 32cf72666f2c86a481277dc6477fab2c
-      - name: 2.2.1--0
-        path: 2.2.1--0/umccrise__2.2.1--0.cwl
-        md5sum: c94a4d335268a2dd3778b054a6bf5f06
       - name: 2.2.0--0
         path: 2.2.0--0/umccrise__2.2.0--0.cwl
         md5sum: 5c8e63abb96cd167d54a800d6a9b373f
+      - name: 2.2.1--0
+        path: 2.2.1--0/umccrise__2.2.1--0.cwl
+        md5sum: c94a4d335268a2dd3778b054a6bf5f06
     categories: []
   - name: custom-create-umccr-dragen-refdata-tarball-from-illumina-tar
     path: custom-create-umccr-dragen-refdata-tarball-from-illumina-tar

--- a/config/tool.yaml
+++ b/config/tool.yaml
@@ -336,6 +336,12 @@ tools:
       - name: 2.1.1--0
         path: 2.1.1--0/umccrise__2.1.1--0.cwl
         md5sum: 32cf72666f2c86a481277dc6477fab2c
+      - name: 2.2.1--0
+        path: 2.2.1--0/umccrise__2.2.1--0.cwl
+        md5sum: c94a4d335268a2dd3778b054a6bf5f06
+      - name: 2.2.0--0
+        path: 2.2.0--0/umccrise__2.2.0--0.cwl
+        md5sum: 5c8e63abb96cd167d54a800d6a9b373f
     categories: []
   - name: custom-create-umccr-dragen-refdata-tarball-from-illumina-tar
     path: custom-create-umccr-dragen-refdata-tarball-from-illumina-tar

--- a/config/user.yaml
+++ b/config/user.yaml
@@ -8,3 +8,5 @@ users:
     email: ywang16@illumina.com
   - username: Stephen Watts
     email: Stephen.Watts@umccr.org
+  - username: Peter Diakumis
+    email: peter.diakumis@umccr.org

--- a/cwl-ica-catalogue.md
+++ b/cwl-ica-catalogue.md
@@ -512,6 +512,8 @@ UMCCR CWL-ICA Catalogue
 - [2.0.2--0](.github/catalogue/docs/tools/umccrise/2.0.2--0/umccrise__2.0.2--0.md)  
 - [2.1.0--0](.github/catalogue/docs/tools/umccrise/2.1.0--0/umccrise__2.1.0--0.md)  
 - [2.1.1--0](.github/catalogue/docs/tools/umccrise/2.1.1--0/umccrise__2.1.1--0.md)  
+- [2.2.0--0](.github/catalogue/docs/tools/umccrise/2.2.0--0/umccrise__2.2.0--0.md)  
+- [2.2.1--0](.github/catalogue/docs/tools/umccrise/2.2.1--0/umccrise__2.2.1--0.md)  
 
 
 ### custom-create-umccr-dragen-refdata-tarball-from-illumina-tar

--- a/tools/umccrise/2.2.0--0/umccrise__2.2.0--0.cwl
+++ b/tools/umccrise/2.2.0--0/umccrise__2.2.0--0.cwl
@@ -1,0 +1,244 @@
+cwlVersion: v1.1
+class: CommandLineTool
+
+# Extensions
+$namespaces:
+    s: https://schema.org/
+    ilmn-tes: http://platform.illumina.com/rdf/ica/
+$schemas:
+  - https://schema.org/version/latest/schemaorg-current-http.rdf
+
+# Metadata
+s:author:
+    class: s:Person
+    s:name: Peter Diakumis
+    s:email: peter.diakumis@umccr.org
+    s:identifier: https://orcid.org/0000-0002-7502-7545
+
+# ID/Docs
+id: umccrise--2.2.0--0
+label: umccrise v(2.2.0--0)
+doc: |
+    Documentation for umccrise v2.2.0--0
+
+# ILMN Resources Guide: https://support-docs.illumina.com/SW/ICA/Content/SW/ICA/RequestResources.htm
+hints:
+    ResourceRequirement:
+        ilmn-tes:resources:
+            tier: standard
+            type: standardHiMem
+            size: medium
+        coresMin: 16
+        ramMin: 50000
+    DockerRequirement:
+        dockerPull: 843407916570.dkr.ecr.ap-southeast-2.amazonaws.com/umccrise:2.2.0-fcef79d982
+
+requirements:
+  InlineJavascriptRequirement:
+    expressionLib:
+      - var get_num_threads = function(){
+          /*
+          Use all cores unless 'threads' is set
+          */
+          if (inputs.threads !== null){
+            return inputs.threads;
+          } else {
+            return runtime.cores;
+          }
+        }
+      - var get_scratch_mount = function() {
+          /*
+          Get the scratch mount directory
+          */
+          return "/scratch";
+        }
+      - var get_name_root_from_tarball = function(tar_file) {
+          /*
+          Get the name of the reference folder
+          */
+          var tar_ball_regex = /(\S+)\.tar\.gz/g;
+          return tar_ball_regex.exec(tar_file)[1];
+        }
+      - var get_genomes_parent_dir = function(){
+          /*
+          Get the genomes directory
+          */
+          return get_scratch_mount() + "/" + "genome_dir";
+        }
+      - var get_scratch_working_parent_dir = function(){
+          /*
+          Get the parent directory for the working directory
+          By just on the off chance someone happens to stupidly set the output as 'genome'
+          */
+          return get_scratch_mount() + "/" + "working_dir";
+        }
+      - var get_scratch_working_dir = function(){
+          /*
+          Get the scratch working directory
+          */
+          return get_scratch_working_parent_dir() + "/" + inputs.output_directory_name;
+        }
+      - var get_scratch_input_dir = function(){
+          /*
+          Get the inputs directory in /scratch space
+          */
+          return get_scratch_mount() + "/" + "inputs";
+        }
+      - var get_genomes_dir_name = function(){
+          /*
+          Return the stripped basename of the genomes tarball
+          */
+          return get_name_root_from_tarball(inputs.genomes_tar.basename);
+        }
+      - var get_genomes_dir_path = function(){
+          /*
+          Get the genomes dir path
+          */
+          return get_genomes_parent_dir() + "/" + get_genomes_dir_name();
+        }
+      - var get_run_script_entryname = function(){
+          /*
+          Get the run script entry name
+          */
+          return "scripts/run-umccrise.sh";
+        }
+      - var get_eval_umccrise_line = function(){
+          /*
+          Get the line eval umccrise...
+          */
+          return "eval \"umccrise\" '\"\$@\"'\n"
+        }
+  InitialWorkDirRequirement:
+    listing:
+      - entryname: "$(get_run_script_entryname())"
+        entry: |
+          #!/usr/bin/env bash
+
+          # Set to fail
+          set -euo pipefail
+
+          # Create parent dir for genomes tmp dir
+          echo "\$(date): Creating parent dir for workspace in scratch" 1>&2
+          mkdir -p "$(get_scratch_working_parent_dir())"
+
+          # Create parent dir for genomes tmp dir
+          echo "\$(date): Creating parent dir for genomes" 1>&2
+          # Create genomes parent directory
+          mkdir -p "$(get_genomes_parent_dir())"
+
+          # Untar umccrise genomes
+          echo "\$(date): Extracting genomes directory into scratch space" 1>&2
+          tar --directory "$(get_genomes_parent_dir())" \\
+            --extract \\
+            --file "$(inputs.genomes_tar.path)"
+
+          # Create input directories
+          mkdir -p "$(get_scratch_input_dir())/$(inputs.dragen_somatic_directory.basename)/"
+          mkdir -p "$(get_scratch_input_dir())/$(inputs.dragen_germline_directory.basename)/"
+
+          # Put inputs into scratch space
+          echo "\$(date): Placing inputs into scratch space" 1>&2
+          cp -r "$(inputs.dragen_somatic_directory.path)/." "$(get_scratch_input_dir())/$(inputs.dragen_somatic_directory.basename)/"
+          cp -r "$(inputs.dragen_germline_directory.path)/." "$(get_scratch_input_dir())/$(inputs.dragen_germline_directory.basename)/"
+
+          # Run umccrise
+          echo "\$(date): Running UMCCrise" 1>&2
+          $(get_eval_umccrise_line())
+
+          # Copy over working directory
+          echo "\$(date): UMCCRise complete, copying over outputs into output directory" 1>&2
+          cp -r "$(get_scratch_working_dir())/." "$(inputs.output_directory_name)/"
+
+          echo "\$(date): Workflow complete!" 1>&2
+
+
+baseCommand: [ "bash" ]
+
+arguments:
+  # Before all other arguments
+  - position: -1
+    valueFrom: "$(get_run_script_entryname())"
+  # Wherever
+  - prefix: "--threads"
+    valueFrom: "$(get_num_threads())"
+  - prefix: "-o"
+    valueFrom: "$(get_scratch_working_dir())"
+
+inputs:
+  # Input folders and files
+  dragen_somatic_directory:
+    label: dragen somatic directory
+    doc: |
+      The dragen somatic directory
+    type: Directory
+    inputBinding:
+      prefix: "--dragen_somatic_dir"
+      valueFrom: |
+        ${
+          return get_scratch_input_dir() + "/" + self.basename;
+        }
+  dragen_germline_directory:
+    label: dragen germline directory
+    doc: |
+      The dragen germline directory
+    type: Directory
+    inputBinding:
+      prefix: "--dragen_germline_dir"
+      valueFrom: |
+        ${
+          return get_scratch_input_dir() + "/" + self.basename;
+        }
+  genomes_tar:
+    label: genomes tar
+    doc: |
+      The reference umccrise tarball
+    type: File
+    inputBinding:
+      prefix: "--genomes-dir"
+      valueFrom: "$(get_genomes_dir_path())"
+  # Input IDs
+  subject_identifier:
+    label: subject identifier
+    doc: |
+      The subject ID (used to name output files)
+    type: string
+    inputBinding:
+      prefix: "--dragen_subject_id"
+  dragen_tumor_id:
+    label: dragen tumor id
+    doc: |
+      The name of the dragen tumor sample
+    type: string
+    inputBinding:
+      prefix: "--dragen_tumor_id"
+  dragen_normal_id:
+    label: dragen normal id
+    doc: |
+      The name of the dragen normal sample
+    type: string
+    inputBinding:
+      prefix: "--dragen_normal_id"
+  # Output names
+  output_directory_name:
+    label: output directory name
+    doc: |
+      The name of the output directory
+    type: string
+  # Optional inputs
+  threads:
+    label: threads
+    doc: |
+      Number of threads to use
+    type: int?
+
+outputs:
+  output_directory:
+    label: output directory
+    doc: |
+      The output directory containing the umccrise data
+    type: Directory
+    outputBinding:
+      glob: "$(inputs.output_directory_name)"
+
+successCodes:
+  - 0

--- a/tools/umccrise/2.2.1--0/umccrise__2.2.1--0.cwl
+++ b/tools/umccrise/2.2.1--0/umccrise__2.2.1--0.cwl
@@ -1,0 +1,244 @@
+cwlVersion: v1.1
+class: CommandLineTool
+
+# Extensions
+$namespaces:
+    s: https://schema.org/
+    ilmn-tes: http://platform.illumina.com/rdf/ica/
+$schemas:
+  - https://schema.org/version/latest/schemaorg-current-http.rdf
+
+# Metadata
+s:author:
+    class: s:Person
+    s:name: Peter Diakumis
+    s:email: peter.diakumis@umccr.org
+    s:identifier: https://orcid.org/0000-0002-7502-7545
+
+# ID/Docs
+id: umccrise--2.2.1--0
+label: umccrise v(2.2.1--0)
+doc: |
+    Documentation for umccrise v2.2.1--0
+
+# ILMN Resources Guide: https://support-docs.illumina.com/SW/ICA/Content/SW/ICA/RequestResources.htm
+hints:
+    ResourceRequirement:
+        ilmn-tes:resources:
+            tier: standard
+            type: standardHiMem
+            size: medium
+        coresMin: 16
+        ramMin: 50000
+    DockerRequirement:
+        dockerPull: 843407916570.dkr.ecr.ap-southeast-2.amazonaws.com/umccrise:2.2.1-8f677de0b9
+
+requirements:
+  InlineJavascriptRequirement:
+    expressionLib:
+      - var get_num_threads = function(){
+          /*
+          Use all cores unless 'threads' is set
+          */
+          if (inputs.threads !== null){
+            return inputs.threads;
+          } else {
+            return runtime.cores;
+          }
+        }
+      - var get_scratch_mount = function() {
+          /*
+          Get the scratch mount directory
+          */
+          return "/scratch";
+        }
+      - var get_name_root_from_tarball = function(tar_file) {
+          /*
+          Get the name of the reference folder
+          */
+          var tar_ball_regex = /(\S+)\.tar\.gz/g;
+          return tar_ball_regex.exec(tar_file)[1];
+        }
+      - var get_genomes_parent_dir = function(){
+          /*
+          Get the genomes directory
+          */
+          return get_scratch_mount() + "/" + "genome_dir";
+        }
+      - var get_scratch_working_parent_dir = function(){
+          /*
+          Get the parent directory for the working directory
+          By just on the off chance someone happens to stupidly set the output as 'genome'
+          */
+          return get_scratch_mount() + "/" + "working_dir";
+        }
+      - var get_scratch_working_dir = function(){
+          /*
+          Get the scratch working directory
+          */
+          return get_scratch_working_parent_dir() + "/" + inputs.output_directory_name;
+        }
+      - var get_scratch_input_dir = function(){
+          /*
+          Get the inputs directory in /scratch space
+          */
+          return get_scratch_mount() + "/" + "inputs";
+        }
+      - var get_genomes_dir_name = function(){
+          /*
+          Return the stripped basename of the genomes tarball
+          */
+          return get_name_root_from_tarball(inputs.genomes_tar.basename);
+        }
+      - var get_genomes_dir_path = function(){
+          /*
+          Get the genomes dir path
+          */
+          return get_genomes_parent_dir() + "/" + get_genomes_dir_name();
+        }
+      - var get_run_script_entryname = function(){
+          /*
+          Get the run script entry name
+          */
+          return "scripts/run-umccrise.sh";
+        }
+      - var get_eval_umccrise_line = function(){
+          /*
+          Get the line eval umccrise...
+          */
+          return "eval \"umccrise\" '\"\$@\"'\n"
+        }
+  InitialWorkDirRequirement:
+    listing:
+      - entryname: "$(get_run_script_entryname())"
+        entry: |
+          #!/usr/bin/env bash
+
+          # Set to fail
+          set -euo pipefail
+
+          # Create parent dir for genomes tmp dir
+          echo "\$(date): Creating parent dir for workspace in scratch" 1>&2
+          mkdir -p "$(get_scratch_working_parent_dir())"
+
+          # Create parent dir for genomes tmp dir
+          echo "\$(date): Creating parent dir for genomes" 1>&2
+          # Create genomes parent directory
+          mkdir -p "$(get_genomes_parent_dir())"
+
+          # Untar umccrise genomes
+          echo "\$(date): Extracting genomes directory into scratch space" 1>&2
+          tar --directory "$(get_genomes_parent_dir())" \\
+            --extract \\
+            --file "$(inputs.genomes_tar.path)"
+
+          # Create input directories
+          mkdir -p "$(get_scratch_input_dir())/$(inputs.dragen_somatic_directory.basename)/"
+          mkdir -p "$(get_scratch_input_dir())/$(inputs.dragen_germline_directory.basename)/"
+
+          # Put inputs into scratch space
+          echo "\$(date): Placing inputs into scratch space" 1>&2
+          cp -r "$(inputs.dragen_somatic_directory.path)/." "$(get_scratch_input_dir())/$(inputs.dragen_somatic_directory.basename)/"
+          cp -r "$(inputs.dragen_germline_directory.path)/." "$(get_scratch_input_dir())/$(inputs.dragen_germline_directory.basename)/"
+
+          # Run umccrise
+          echo "\$(date): Running UMCCrise" 1>&2
+          $(get_eval_umccrise_line())
+
+          # Copy over working directory
+          echo "\$(date): UMCCRise complete, copying over outputs into output directory" 1>&2
+          cp -r "$(get_scratch_working_dir())/." "$(inputs.output_directory_name)/"
+
+          echo "\$(date): Workflow complete!" 1>&2
+
+
+baseCommand: [ "bash" ]
+
+arguments:
+  # Before all other arguments
+  - position: -1
+    valueFrom: "$(get_run_script_entryname())"
+  # Wherever
+  - prefix: "--threads"
+    valueFrom: "$(get_num_threads())"
+  - prefix: "-o"
+    valueFrom: "$(get_scratch_working_dir())"
+
+inputs:
+  # Input folders and files
+  dragen_somatic_directory:
+    label: dragen somatic directory
+    doc: |
+      The dragen somatic directory
+    type: Directory
+    inputBinding:
+      prefix: "--dragen_somatic_dir"
+      valueFrom: |
+        ${
+          return get_scratch_input_dir() + "/" + self.basename;
+        }
+  dragen_germline_directory:
+    label: dragen germline directory
+    doc: |
+      The dragen germline directory
+    type: Directory
+    inputBinding:
+      prefix: "--dragen_germline_dir"
+      valueFrom: |
+        ${
+          return get_scratch_input_dir() + "/" + self.basename;
+        }
+  genomes_tar:
+    label: genomes tar
+    doc: |
+      The reference umccrise tarball
+    type: File
+    inputBinding:
+      prefix: "--genomes-dir"
+      valueFrom: "$(get_genomes_dir_path())"
+  # Input IDs
+  subject_identifier:
+    label: subject identifier
+    doc: |
+      The subject ID (used to name output files)
+    type: string
+    inputBinding:
+      prefix: "--dragen_subject_id"
+  dragen_tumor_id:
+    label: dragen tumor id
+    doc: |
+      The name of the dragen tumor sample
+    type: string
+    inputBinding:
+      prefix: "--dragen_tumor_id"
+  dragen_normal_id:
+    label: dragen normal id
+    doc: |
+      The name of the dragen normal sample
+    type: string
+    inputBinding:
+      prefix: "--dragen_normal_id"
+  # Output names
+  output_directory_name:
+    label: output directory name
+    doc: |
+      The name of the output directory
+    type: string
+  # Optional inputs
+  threads:
+    label: threads
+    doc: |
+      Number of threads to use
+    type: int?
+
+outputs:
+  output_directory:
+    label: output directory
+    doc: |
+      The output directory containing the umccrise data
+    type: Directory
+    outputBinding:
+      glob: "$(inputs.output_directory_name)"
+
+successCodes:
+  - 0


### PR DESCRIPTION
Adding tools for v2.2.0 and v2.2.1 of umccrise. I'm not touching the workflow side of things since I believe that's being worked on a separate branch.
Keeping track of steps here:

- Step 0:

```bash
cwl-ica configure-user \
  --username "Peter Parker" \
  --email "peter.parker@marvel.org" \
  --set-as-default
```

- Step 1:
 
```
cwl-ica create-tool-from-template \
  --tool-name umccrise \
  --tool-version 2.2.0 \
  --username "Peter Parker"
```

Then edit the rest of `tools/umccrise/2.2.0--0/umccrise__2.2.0--0.cwl` according to the previous version of the tool.

- Step 2:

```
cwl-ica tool-validate \
  --tool-path "tools/umccrise/2.2.0--0/umccrise__2.2.0--0.cwl"
```

- Step 3:

```
cwl-ica tool-init \
  --tool-path "tools/umccrise/2.2.0--0/umccrise__2.2.0--0.cwl"
```

Needed to also do `chmod +x ${CONDA_PREFIX}/etc/get_api_key.sh`