### PR TITLE
Updated booleans for dragen 3.9 pipelines

### DIFF
--- a/config/project.yaml
+++ b/config/project.yaml
@@ -492,7 +492,7 @@ projects:
           - name: 3.9.3
             path: 3.9.3/dragen-germline-pipeline__3.9.3.cwl
             ica_workflow_version_name: 3.9.3
-            modification_time: 2022-10-11T06:46:44UTC
+            modification_time: 2022-10-20T04:59:22UTC
             run_instances:
               - wfr.d058e5f7be4b4683a9b1a59b8f67f91b
               - wfr.4759b2ccf6234141b06d5aab5b932dbb
@@ -531,7 +531,7 @@ projects:
           - name: 3.9.3
             path: 3.9.3/dragen-somatic-pipeline__3.9.3.cwl
             ica_workflow_version_name: 3.9.3
-            modification_time: 2022-10-11T06:46:56UTC
+            modification_time: 2022-10-20T05:00:01UTC
             run_instances:
               - wfr.b19291caab384e78b7661a85c3f82003
               - wfr.128790246e9c48f39e14d8f8ef7d868e
@@ -567,7 +567,7 @@ projects:
           - name: 3.9.3
             path: 3.9.3/dragen-transcriptome-pipeline__3.9.3.cwl
             ica_workflow_version_name: 3.9.3
-            modification_time: 2022-10-11T06:47:06UTC
+            modification_time: 2022-10-20T05:00:38UTC
             run_instances:
               - wfr.784173de5b4342b797f04259ebd04df6
               - wfr.f75bddad9d4740d3873fce5ceb782bc7
@@ -585,7 +585,7 @@ projects:
           - name: 3.9.3
             path: 3.9.3/dragen-alignment-pipeline__3.9.3.cwl
             ica_workflow_version_name: 3.9.3
-            modification_time: 2022-10-11T06:47:12UTC
+            modification_time: 2022-10-20T04:58:43UTC
             run_instances: []
       - name: dragen-wgs-qc-pipeline
         path: dragen-wgs-qc-pipeline
@@ -601,7 +601,7 @@ projects:
           - name: 3.9.3
             path: 3.9.3/dragen-wgs-qc-pipeline__3.9.3.cwl
             ica_workflow_version_name: 3.9.3
-            modification_time: 2022-10-11T06:47:17UTC
+            modification_time: 2022-10-20T05:03:36UTC
             run_instances:
               - wfr.8bb7083dc6e74a2f9c21edd65e627a2e
       - name: tso500-ctdna-post-processing-pipeline

--- a/config/workflow.yaml
+++ b/config/workflow.yaml
@@ -22,7 +22,7 @@ workflows:
         md5sum: 76fd126b16ba8a2734f2b0ecb681754b
       - name: 3.9.3
         path: 3.9.3/dragen-germline-pipeline__3.9.3.cwl
-        md5sum: d394d2fb01674978ba45646d13469e65
+        md5sum: 28bfaad1194d2f7d1f8608401dd79685
     categories:
       - dragen
   - name: dragen-qc-hla-pipeline
@@ -55,7 +55,7 @@ workflows:
         md5sum: 8add78db7d0979d95726137d3d5b0b9a
       - name: 3.9.3
         path: 3.9.3/dragen-somatic-pipeline__3.9.3.cwl
-        md5sum: 8944136c8c14a1b2bef724f7910fb963
+        md5sum: d45f5583db373a69a9d04014b3978371
     categories:
       - dragen
       - variant-calling
@@ -70,7 +70,7 @@ workflows:
         md5sum: 830464ca802948cd5212a7d1abdd2a35
       - name: 3.9.3
         path: 3.9.3/dragen-transcriptome-pipeline__3.9.3.cwl
-        md5sum: 58a1ca987fc490e5ddf67c14c3f5f880
+        md5sum: 29c45cfadc3f1b8d0e90d2086c233c42
     categories: []
   - name: dragen-alignment-pipeline
     path: dragen-alignment-pipeline
@@ -80,7 +80,7 @@ workflows:
         md5sum: 6a2df7e5f61dad1e986ab683a5362fed
       - name: 3.9.3
         path: 3.9.3/dragen-alignment-pipeline__3.9.3.cwl
-        md5sum: b5c8752262345756a15aaf7e61c307d5
+        md5sum: 3fe6faf5fb177337bf7fc8c347494520
     categories:
       - alignment
       - dragen
@@ -92,7 +92,7 @@ workflows:
         md5sum: 96bc9c833ca8d4f8ef676776e382a436
       - name: 3.9.3
         path: 3.9.3/dragen-wgs-qc-pipeline__3.9.3.cwl
-        md5sum: d693c2dfd00449b2ab5e05e9b61aac6b
+        md5sum: 414f7d38adeeea505937de707fe9fb11
     categories:
       - dragen
   - name: tso500-ctdna-post-processing-pipeline

--- a/tools/dragen-alignment/3.9.3/dragen-alignment__3.9.3.cwl
+++ b/tools/dragen-alignment/3.9.3/dragen-alignment__3.9.3.cwl
@@ -361,13 +361,13 @@ inputs:
     type: int?
     inputBinding:
       prefix: "--Mapper.edit-seed-num"
-  enable_map_align:
-    label: enable map align
+  enable_map_align_output:
+    label: enable map align output
     doc: |
       Enable use of BAM input files for mapper/aligner.
-    type: boolean?
+    type: boolean
     inputBinding:
-      prefix: "--enable-map-align"
+      prefix: "--enable-map-align-output"
       valueFrom: "$(self.toString())"
   max_intron_bases:
     label: max intron bases
@@ -671,7 +671,7 @@ inputs:
     label: enable duplicate marking
     doc: |
       Enable the flagging of duplicate output alignment records.
-    type: boolean?
+    type: boolean
     inputBinding:
       prefix: "--enable-duplicate-marking"
       valueFrom: "$(self.toString())"
@@ -713,7 +713,7 @@ inputs:
     label: enable sort
     doc: |
       Enable sorting after mapping/alignment.
-    type: boolean?
+    type: boolean
     inputBinding:
       prefix: "--enable-sort"
       valueFrom: "$(self.toString())"

--- a/tools/dragen-germline/3.9.3/dragen-germline__3.9.3.cwl
+++ b/tools/dragen-germline/3.9.3/dragen-germline__3.9.3.cwl
@@ -323,7 +323,7 @@ inputs:
     label: enable map align output
     doc: |
       Do you wish to have the output bam files present
-    type: boolean?
+    type: boolean
     inputBinding:
       prefix: "--enable-map-align-output"
       valueFrom: "$(self.toString())"
@@ -331,7 +331,7 @@ inputs:
     label: enable duplicate marking
     doc: |
       Mark identical alignments as duplicates
-    type: boolean?
+    type: boolean
     inputBinding:
       prefix: "--enable-duplicate-marking"
       valueFrom: "$(self.toString())"

--- a/tools/dragen-somatic/3.9.3/dragen-somatic__3.9.3.cwl
+++ b/tools/dragen-somatic/3.9.3/dragen-somatic__3.9.3.cwl
@@ -500,7 +500,7 @@ inputs:
       map/align stage. Default is true when only
       running map/align. Default is false if
       running the variant caller.
-    type: boolean?
+    type: boolean
     inputBinding:
       prefix: "--enable-map-align-output"
       valueFrom: "$(self.toString())"
@@ -509,7 +509,7 @@ inputs:
     doc: |
       Enable the flagging of duplicate output
       alignment records.
-    type: boolean?
+    type: boolean
     inputBinding:
       prefix: "--enable-duplicate-marking"
       valueFrom: "$(self.toString())"

--- a/tools/dragen-transcriptome/3.9.3/dragen-transcriptome__3.9.3.cwl
+++ b/tools/dragen-transcriptome/3.9.3/dragen-transcriptome__3.9.3.cwl
@@ -297,7 +297,7 @@ inputs:
     label: enable map align output
     doc: |
       Do you wish to have the output bam files present
-    type: boolean?
+    type: boolean
     inputBinding:
       prefix: "--enable-map-align-output"
       valueFrom: "$(self.toString())"
@@ -305,7 +305,7 @@ inputs:
     label: enable duplicate marking
     doc: |
       Mark identical alignments as duplicates
-    type: boolean?
+    type: boolean
     inputBinding:
       prefix: "--enable-duplicate-marking"
       valueFrom: "$(self.toString())"

--- a/workflows/dragen-alignment-pipeline/3.9.3/dragen-alignment-pipeline__3.9.3.cwl
+++ b/workflows/dragen-alignment-pipeline/3.9.3/dragen-alignment-pipeline__3.9.3.cwl
@@ -103,11 +103,11 @@ inputs:
       For edit-mode 1 or 2: Requested number of seeds per read to allow editing on.
       Range: > 0
     type: int?
-  enable_map_align:
-    label: enable map align
+  enable_map_align_output:
+    label: enable map align output
     doc: |
       Enable use of BAM input files for mapper/aligner.
-    type: boolean?
+    type: boolean
   max_intron_bases:
     label: max intron bases
     doc: |
@@ -329,7 +329,7 @@ inputs:
     label: enable duplicate marking
     doc: |
       Enable the flagging of duplicate output alignment records.
-    type: boolean?
+    type: boolean
   remove_duplicates:
     label: remove duplicates
     doc: |
@@ -356,7 +356,7 @@ inputs:
     label: enable sort
     doc: |
       Enable sorting after mapping/alignment.
-    type: boolean?
+    type: boolean
   preserve_map_align_order:
     label: preserve map align order
     doc: |
@@ -399,8 +399,8 @@ steps:
         source: edit_read_len
       edit_seed_num:
         source: edit_seed_num
-      enable_map_align:
-        source: enable_map_align
+      enable_map_align_output:
+        source: enable_map_align_output
       max_intron_bases:
         source: max_intron_bases
       min_intron_bases:

--- a/workflows/dragen-germline-pipeline/3.9.3/dragen-germline-pipeline__3.9.3.cwl
+++ b/workflows/dragen-germline-pipeline/3.9.3/dragen-germline-pipeline__3.9.3.cwl
@@ -87,13 +87,13 @@ inputs:
       map/align stage. Default is true when only
       running map/align. Default is false if
       running the variant caller.
-    type: boolean?
+    type: boolean
   enable_duplicate_marking:
     label: enable duplicate marking
     doc: |
       Enable the flagging of duplicate output
       alignment records.
-    type: boolean?
+    type: boolean
   dedup_min_qual:
     label: deduplicate minimum quality
     doc: |

--- a/workflows/dragen-somatic-pipeline/3.9.3/dragen-somatic-pipeline__3.9.3.cwl
+++ b/workflows/dragen-somatic-pipeline/3.9.3/dragen-somatic-pipeline__3.9.3.cwl
@@ -128,13 +128,13 @@ inputs:
       map/align stage. Default is true when only
       running map/align. Default is false if
       running the variant caller.
-    type: boolean?
+    type: boolean
   enable_duplicate_marking:
     label: enable duplicate marking
     doc: |
       Enable the flagging of duplicate output
       alignment records.
-    type: boolean?
+    type: boolean
   enable_sv:
     label: enable sv
     doc: |

--- a/workflows/dragen-transcriptome-pipeline/3.9.3/dragen-transcriptome-pipeline__3.9.3.cwl
+++ b/workflows/dragen-transcriptome-pipeline/3.9.3/dragen-transcriptome-pipeline__3.9.3.cwl
@@ -76,12 +76,12 @@ inputs:
     label: enable map align output
     doc: |
       Do you wish to have the output bam files present
-    type: boolean?
+    type: boolean
   enable_duplicate_marking:
     label: enable duplicate marking
     doc: |
       Mark identical alignments as duplicates
-    type: boolean?
+    type: boolean
   # Quantification options
   enable_rna_quantification:
     label: enable rna quantification

--- a/workflows/dragen-wgs-qc-pipeline/3.9.3/dragen-wgs-qc-pipeline__3.9.3.cwl
+++ b/workflows/dragen-wgs-qc-pipeline/3.9.3/dragen-wgs-qc-pipeline__3.9.3.cwl
@@ -48,6 +48,17 @@ inputs:
     doc: |
       Path to ref data tarball
     type: File
+  # Dragen alignment options
+  enable_duplicate_marking:
+    label: enable duplicate marking
+    doc: |
+      Mark identical alignments as duplicates
+    type: boolean
+  enable_map_align_output:
+    label: enable map align output
+    doc: |
+      Do you wish to have the output bam files present
+    type: boolean
   # Output naming options
   output_file_prefix:
     label: output file prefix
@@ -59,23 +70,7 @@ inputs:
     doc: |
       The directory where all output files are placed
     type: string
-  # Somalier Options
-  sites_somalier:
-    label: sites somalier
-    doc: |
-      gzipped vcf file. Required for somalier sites
-    type: File
-    secondaryFiles:
-      - pattern: ".tbi"
-        required: true
-  reference_fasta:
-    label: reference fasta
-    type: File
-    doc: |
-      FastA file with genome sequence
-    secondaryFiles:
-      - pattern: ".fai"
-        required: true
+
 
 steps:
   # Step-1: run subworkflow that mainly calls Dragen and multiQC
@@ -95,40 +90,15 @@ steps:
       output_directory:
         source: output_directory
       # Output configurations
-      enable_map_align:
-        valueFrom: ${ return true; }
+      enable_map_align_output:
+        source: enable_map_align_output
       enable_duplicate_marking:
-        valueFrom: ${ return true; }
+        source: enable_duplicate_marking
     out:
       - id: dragen_alignment_output_directory
       - id: dragen_bam_out
       - id: multiqc_output_directory
     run: ../../../workflows/dragen-alignment-pipeline/3.9.3/dragen-alignment-pipeline__3.9.3.cwl
-
-  # Step-2: run somalier
-  run_somalier_step:
-    label: somalier
-    doc: |
-      Runs the somalier extract function to call the fingerprint on the germline bam file
-    in:
-      bam_sorted:
-        # The bam from the dragen germline workflow
-        source: run_dragen_step/dragen_bam_out
-      sites:
-        # The VCF output file from the dragen command
-        source: sites_somalier
-      reference:
-        # The reference fasta for the genome somalier
-        source: reference_fasta
-      sample_prefix:
-        source: output_file_prefix
-        # The output-prefix, if not specified just the sample name
-      output_directory_name:
-        source: output_directory
-        valueFrom: "$(self)_somalier"
-    out:
-      - id: output_directory
-    run: ../../../tools/somalier-extract/0.2.13/somalier-extract__0.2.13.cwl
 
 outputs:
   # All output files will be under the output directory

--- a/workflows/dragen-wgs-qc-pipeline/3.9.3/dragen-wgs-qc-pipeline__3.9.3.cwl
+++ b/workflows/dragen-wgs-qc-pipeline/3.9.3/dragen-wgs-qc-pipeline__3.9.3.cwl
@@ -59,6 +59,12 @@ inputs:
     doc: |
       Do you wish to have the output bam files present
     type: boolean
+  enable_sort:
+    label: enable sort
+    doc: |
+      The map/align system produces a BAM file sorted by 
+      reference sequence and position by default.
+    type: boolean
   # Output naming options
   output_file_prefix:
     label: output file prefix
@@ -94,6 +100,8 @@ steps:
         source: enable_map_align_output
       enable_duplicate_marking:
         source: enable_duplicate_marking
+      enable_sort:
+        source: enable_sort
     out:
       - id: dragen_alignment_output_directory
       - id: dragen_bam_out
@@ -123,10 +131,4 @@ outputs:
       The dragen multiQC output
     type: Directory
     outputSource: run_dragen_step/multiqc_output_directory
-  # Somalier outputs
-  somalier_output_directory:
-    label: somalier output directory
-    doc: |
-      Output directory from somalier step
-    type: Directory
-    outputSource: run_somalier_step/output_directory
+


### PR DESCRIPTION
## Updates

### dragen-alignment v3.9.3 tool/pipeline

* enable_map_align parameter renamed to enable_map_align_output
	*  --enable-map-align is set to true by default. 
	* --enable-map-align is set to true by default when --enable-map-align-output is set so no changes to outputs, just makes it more consistent with other workflows
	* enable_map_align_output parameter now mandatory
* enable_sort parameter now mandatory
* enable_duplicate_marking parameter now mandatory


### dragen germline v3.9.3 tool/pipeline

* enable_map_align_output parameter now mandatory
* enable_duplicate_marking parameter now mandatory

### dragen transcriptome v3.9.3 tool/pipeline

* enable_map_align_output parameter now mandatory
* enable_duplicate_marking parameter now mandatory

### dragen somatic v3.9.3 tool/pipeline

* enable_map_align_output parameter now mandatory
* enable_duplicate_marking parameter now mandatory

### dragen-wgs-qc pipeline v3.9.3 tool/pipeline

* enable_map_align_output parameter now mandatory
* enable_duplicate_marking parameter now mandatory
* enable_sort parameter now mandatory
* removed somalier step and outputs


