### PR TITLE
Sync tools and workflows GH Actions Update

### DIFF
--- a/.github/workflows/sync-tools_and_sync-workflows.yml
+++ b/.github/workflows/sync-tools_and_sync-workflows.yml
@@ -114,7 +114,7 @@ jobs:
       - name: get collab illumina dev workflows project id access token
         id: get_collab_illumina_dev_workflows_project_id_access_token
         run: |
-          collab_illumina_dev_workflows_project_id="0df0356d-3637-48a5-80d1-a924642a6556"
+          collab_illumina_dev_workflows_project_id="dddd6c29-24d3-49f4-91c0-7e818b3c0a21"
           echo "ica_access_token=$( \
             AWS_ACCESS_KEY_ID="${{ secrets.AWS_ACCESS_KEY_ID_DEV_ICA_SECRETS_WORKFLOW }}" \
             AWS_SECRET_ACCESS_KEY="${{ secrets.AWS_SECRET_ACCESS_KEY_DEV_ICA_SECRETS_WORKFLOW }}" \

--- a/.github/workflows/sync-tools_and_sync-workflows.yml
+++ b/.github/workflows/sync-tools_and_sync-workflows.yml
@@ -95,7 +95,7 @@ jobs:
         id: get_development_workflows_project_id_access_token
         run: |
           development_workflows_project_id="0df0356d-3637-48a5-80d1-a924642a6556"
-          echo "ica_access_token=$( \
+          development_workflows_access_token="$( \
             AWS_ACCESS_KEY_ID="${{ secrets.AWS_ACCESS_KEY_ID_DEV_ICA_SECRETS_WORKFLOW }}" \
             AWS_SECRET_ACCESS_KEY="${{ secrets.AWS_SECRET_ACCESS_KEY_DEV_ICA_SECRETS_WORKFLOW }}" \
             AWS_REGION="${{ secrets.AWS_REGION }}" \
@@ -109,13 +109,15 @@ jobs:
                   fromjson | 
                   .[$project_id]
                 ' \
-          )" >> "${GITHUB_OUTPUT}"
+          )"
+          echo "::add-mask::${development_workflows_access_token}"
+          echo "ica_access_token=${development_workflows_access_token}" >> "${GITHUB_OUTPUT}"
       # Get collab illumina dev workflows access token
       - name: get collab illumina dev workflows project id access token
         id: get_collab_illumina_dev_workflows_project_id_access_token
         run: |
           collab_illumina_dev_workflows_project_id="dddd6c29-24d3-49f4-91c0-7e818b3c0a21"
-          echo "ica_access_token=$( \
+          collab_illumina_dev_access_token="$( \
             AWS_ACCESS_KEY_ID="${{ secrets.AWS_ACCESS_KEY_ID_DEV_ICA_SECRETS_WORKFLOW }}" \
             AWS_SECRET_ACCESS_KEY="${{ secrets.AWS_SECRET_ACCESS_KEY_DEV_ICA_SECRETS_WORKFLOW }}" \
             AWS_REGION="${{ secrets.AWS_REGION }}" \
@@ -129,13 +131,15 @@ jobs:
                   fromjson | 
                   .[$project_id]
                 ' \
-          )" >> "${GITHUB_OUTPUT}"
+          )" 
+          echo "::add-mask::${collab_illumina_dev_access_token}"
+          echo "ica_access_token=${collab_illumina_dev_access_token}" >> "${GITHUB_OUTPUT}"
       # Get production workflows access token
       - name: get production workflows project id access token
         id: get_production_workflows_project_id_access_token
         run: |
-          production_workflows="fdd48e11-cdcc-46a9-b5ac-dee3a4c5f19d"
-          echo "ica_access_token=$( \
+          production_workflows_project_id="fdd48e11-cdcc-46a9-b5ac-dee3a4c5f19d"
+          production_workflows_access_token="$( \
             AWS_ACCESS_KEY_ID="${{ secrets.AWS_ACCESS_KEY_ID_PROD_ICA_SECRETS_WORKFLOW }}" \
             AWS_SECRET_ACCESS_KEY="${{ secrets.AWS_SECRET_ACCESS_KEY_PROD_ICA_SECRETS_WORKFLOW }}" \
             AWS_REGION="${{ secrets.AWS_REGION }}" \
@@ -143,18 +147,20 @@ jobs:
                 --output json \
                 --secret-id IcaSecretsWorkflow | \
               jq --raw-output \
-                --arg project_id "${production_workflows}" \
+                --arg project_id "${production_workflows_project_id}" \
                 '
                   .SecretString | 
                   fromjson | 
                   .[$project_id]
                 ' \
-          )" >> "${GITHUB_OUTPUT}"
+          )"
+          echo "::add-mask::${production_workflows_access_token}"
+          echo "ica_access_token=${production_workflows_access_token}" >> "${GITHUB_OUTPUT}"
       # Create secrets json
       - name: create secrets json
         id: create_secrets_json
         run: |
-          echo "secrets_json=$( \
+          secrets_json="$( \
             jq --null-input --raw-output \
               --arg development_workflows_access_token "${{ steps.get_development_workflows_project_id_access_token.outputs.ica_access_token }}" \
               --arg collab_illumina_dev_workflows_access_token "${{ steps.get_collab_illumina_dev_workflows_project_id_access_token.outputs.ica_access_token }}" \
@@ -173,7 +179,9 @@ jobs:
                 } |
                 @base64
               ' \
-          )" >> "${GITHUB_OUTPUT}"
+          )" 
+          echo "::add-mask::${secrets_json}"
+          echo "secrets_json=${secrets_json}" >> "${GITHUB_OUTPUT}"
       # Sync tools and workflows
       - name: sync-tools and sync-workflows
         run: |

--- a/.github/workflows/sync-tools_and_sync-workflows.yml
+++ b/.github/workflows/sync-tools_and_sync-workflows.yml
@@ -27,20 +27,21 @@ jobs:
     name: sync-tools and sync-workflows and create-catalogue
     concurrency: git_commits
     runs-on: ubuntu-latest
+    defaults:
+      run:
+        shell: bash -euo pipefail
     steps:
       # # DEBUG
       # - uses: hmarr/debug-action@v2
       # Install jq (for querying branch name)
       - name: Install Jq
         id: install_jq
-        shell: bash
         run: |
           sudo apt-get update -y
           sudo apt-get install jq -y
       # Get branch name from event path
       - name: Get Branch Name
         id: get_branch_name
-        shell: bash
         run: |
           # Get reference
           ref="$( \
@@ -72,7 +73,7 @@ jobs:
           fi
           
           # Set output
-          echo "::set-output name=branch_name::${ref%refs/heads/}"
+          echo "branch_name=${ref%refs/heads/}" >> "${GITHUB_OUTPUT}"
       # Standard checkout step
       - name: Checkout code
         id: git_checkout
@@ -83,15 +84,16 @@ jobs:
       # Get git commit ID
       - name: Get git commit ID
         id: get_git_commit_id
-        run: echo "::set-output name=git_commit_id::$(git log --format="%H" -n1 | cut -c1-7)"
+        run: echo "git_commit_id=$(git log --format="%H" -n1 | cut -c1-7)" >> "${GITHUB_OUTPUT}"
       # Get development workflows access token
       - name: get development workflows project id access token
         id: get_development_workflows_project_id_access_token
         run: |
           development_workflows_project_id="0df0356d-3637-48a5-80d1-a924642a6556"
-          echo "::set-output name=ica_access_token::$( \
+          echo "ica_access_token=$( \
             AWS_ACCESS_KEY_ID="${{ secrets.AWS_ACCESS_KEY_ID_DEV_ICA_SECRETS_WORKFLOW }}" \
             AWS_SECRET_ACCESS_KEY="${{ secrets.AWS_SECRET_ACCESS_KEY_DEV_ICA_SECRETS_WORKFLOW }}" \
+            AWS_REGION="${{ secrets.AWS_REGION }}" \
               aws secretsmanager get-secret-value \
                 --output json \
                 --secret-id IcaSecretsWorkflow  | \
@@ -102,15 +104,16 @@ jobs:
                   fromjson | 
                   .[$project_id]
                 ' \
-          )"
+          )" >> "${GITHUB_OUTPUT}"
       # Get collab illumina dev workflows access token
       - name: get collab illumina dev workflows project id access token
         id: get_collab_illumina_dev_workflows_project_id_access_token
         run: |
           collab_illumina_dev_workflows_project_id="0df0356d-3637-48a5-80d1-a924642a6556"
-          echo "::set-output name=ica_access_token::$( \
+          echo "ica_access_token=$( \
             AWS_ACCESS_KEY_ID="${{ secrets.AWS_ACCESS_KEY_ID_DEV_ICA_SECRETS_WORKFLOW }}" \
             AWS_SECRET_ACCESS_KEY="${{ secrets.AWS_SECRET_ACCESS_KEY_DEV_ICA_SECRETS_WORKFLOW }}" \
+            AWS_REGION="${{ secrets.AWS_REGION }}" \
               aws secretsmanager get-secret-value \
                 --output json \
                 --secret-id IcaSecretsWorkflow  | \
@@ -121,15 +124,16 @@ jobs:
                   fromjson | 
                   .[$project_id]
                 ' \
-          )"
+          )" >> "${GITHUB_OUTPUT}"
       # Get production workflows access token
       - name: get production workflows project id access token
         id: get_production_workflows_project_id_access_token
         run: |
           production_workflows="fdd48e11-cdcc-46a9-b5ac-dee3a4c5f19d"
-          echo "::set-output name=ica_access_token::$( \
+          echo "ica_access_token=$( \
             AWS_ACCESS_KEY_ID="${{ secrets.AWS_ACCESS_KEY_ID_PROD_ICA_SECRETS_WORKFLOW }}" \
             AWS_SECRET_ACCESS_KEY="${{ secrets.AWS_SECRET_ACCESS_KEY_PROD_ICA_SECRETS_WORKFLOW }}" \
+            AWS_REGION="${{ secrets.AWS_REGION }}" \
               aws secretsmanager get-secret-value \
                 --output json \
                 --secret-id IcaSecretsWorkflow | \
@@ -140,12 +144,12 @@ jobs:
                   fromjson | 
                   .[$project_id]
                 ' \
-          )"
+          )" >> "${GITHUB_OUTPUT}"
       # Create secrets json
       - name: create secrets json
         id: create_secrets_json
         run: |
-          echo "::set-output name=secrets_json::$( \
+          echo "secrets_json=$( \
             jq --null-input --raw-output \
               --arg development_workflows_access_token "${{ steps.get_development_workflows_project_id_access_token.outputs.ica_access_token }}" \
               --arg collab_illumina_dev_workflows_access_token "${{ steps.get_collab_illumina_dev_workflows_project_id_access_token.outputs.ica_access_token }}" \
@@ -164,7 +168,7 @@ jobs:
                 } |
                 @base64
               ' \
-          )"
+          )" >> "${GITHUB_OUTPUT}"
       # Sync tools and workflows
       - name: sync-tools and sync-workflows
         run: |

--- a/.github/workflows/sync-tools_and_sync-workflows.yml
+++ b/.github/workflows/sync-tools_and_sync-workflows.yml
@@ -29,10 +29,15 @@ jobs:
     runs-on: ubuntu-latest
     defaults:
       run:
-        shell: bash -euo pipefail
+        shell: bash -l {0}
     steps:
       # # DEBUG
       # - uses: hmarr/debug-action@v2
+      # Set to fail
+      - name: Update bash settings
+        id: update_bash_settings
+        run: |
+          set -euo pipefail
       # Install jq (for querying branch name)
       - name: Install Jq
         id: install_jq

--- a/.github/workflows/sync-tools_and_sync-workflows.yml
+++ b/.github/workflows/sync-tools_and_sync-workflows.yml
@@ -184,7 +184,7 @@ jobs:
             --workdir "$PWD" \
             --env USER="$(id -u)" \
             --env GIT_COMMIT_ID="${{ steps.get_git_commit_id.outputs.git_commit_id }}" \
-            --env SECRETS_JSON="${{ secrets.ICA_ACCESS_TOKENS_JSON }}" \
+            --env SECRETS_JSON="${{ steps.create_secrets_json.outputs.secrets_json }}" \
             --env ICA_BASE_URL="${{ secrets.ICA_BASE_URL }}" \
             ghcr.io/umccr/cwl-ica-cli:latest \
               bash ".github/scripts/run_sync-tools_and_sync-workflows.sh"


### PR DESCRIPTION
* Use bash -euo pipefail as default shell
* Migrated away from deprecated set-output to GITHUB_OUTPUT for setting outputs for workflow steps
* Set AWS_REGION value as a secret


Fixes #175 