### PR TITLE
Set CONDA ENVS PATH

### DIFF
--- a/.github/scripts/run_sync-tools_and_sync-workflows.sh
+++ b/.github/scripts/run_sync-tools_and_sync-workflows.sh
@@ -46,20 +46,35 @@ for project in $(echo "${SECRETS_JSON}" | jq -r 'keys[]'); do
     export "${project_token_env_var_name}"="${project_token}"
 done
 
+# Set conda env path
+export CONDA_ENVS_PATH="$(mktemp -d)"
+
+# Softlink envs into this environment
+ENVS_LIST=( "cwl-ica" "cwltool-icav1" )
+for env_name in "${ENVS_LIST[@]}"; do
+  ln -s \
+    /home/cwl_ica_user/.conda/envs/${env_name} \
+    "${CONDA_ENVS_PATH}/${env_name}"
+done
+
 # Now run the github-schema-sync-command
 echo "Syncing all schemas" 1>&2
-cwl-ica github-actions-sync-schemas
+conda run --name cwl-ica \
+  cwl-ica github-actions-sync-schemas
 
 # Now run the github-expression-sync-command
 echo "Syncing all expressions" 1>&2
-cwl-ica github-actions-sync-expressions
+conda run --name cwl-ica \
+  cwl-ica github-actions-sync-expressions
 
 # Now run the github-tool-sync-command
 echo "Syncing all tools" 1>&2
-cwl-ica github-actions-sync-tools \
+conda run --name cwl-ica \
+  cwl-ica github-actions-sync-tools \
 
 # Now run the github-workflow-sync-command
 echo "Syncing all workflows" 1>&2
-cwl-ica github-actions-sync-workflows
+conda run --name cwl-ica \
+  cwl-ica github-actions-sync-workflows
 
 


### PR DESCRIPTION
## Prologue

If someone ever stumbles upon this in the future, please read the justification section below to see a great example of why the number of lines of code doesn't always correlate with productivity/effort [cough, cough Elon!](https://slate.com/technology/2022/11/elon-musk-twitter-code-fixation.html)

## Code Updates 

* Update CONDA_ENVS_PATH in sync script
* Link cwl-ica-user conda envs into docker user ENV PATH
* and also use the conda run to ensure the cwl-ica is being invoked from the docker user env path as well, seems like a better practise.

## Justification

After the release of [cwl-ica-cli 1.4.2](https://github.com/umccr/cwl-ica-cli/releases/tag/v1.4.2), GitHub actions sync was failing with permissions issues.  This can be traced back to this [PR](https://github.com/umccr/cwl-ica-cli/pull/108). 

The troublesome PR aimed to reduce the amount of time taken for the GitHub action 'sync-workflows' to complete. The previous logic created a new pyenv everytime a cwltool validation was required so instead we tried creating a separate conda env in the installation that had the legacy version of cwltool installed. The cwltool validation was then invoked by prefixing `conda run --name cwltool-icav1`.  

The separate pyenv for cwltool logic was introduced in [cwl-ica-cli 1.4.0](https://github.com/umccr/cwl-ica-cli/releases/tag/v1.4.0) to allow us to use the latest version of cwl-utils AND also have the legacy version of cwltool, which were not compatible in the same python env.

So here we are, with a set of permissions issues. 

As it turns out, the permission errors were due to three factors:

1. The `conda run` cli previously created a bash script INSIDE the environment, which meant that any conda run command that called a read-only environment would fail. This was fixed in https://github.com/conda/conda/pull/11215 which meant upgrading the docker base image. Fixed in https://github.com/umccr/cwl-ica-cli/pull/112. One line of code that took a few hours to get to the bottom of!

2. The [documentation for using Docker on GitHub Actions](https://docs.github.com/en/actions/creating-actions/dockerfile-support-for-github-actions#user) notes that one should NOT use the USER instruction in the DockerFile.  Essentially it is asking one to run all GitHub actions containers as root, which is an unnecessary security risk. In the past we have worked around this by mapping the GitHub actions user to the container with `--user $(id -u):$(id -g)` and `--env USER=$(id -u)`.  Aside from the user in the docker script being both without a name or home directory, they also do not have the same grouping as the *cwl_ica_user* (which is the name of the default user for the cwl-ica-cli container that GitHub actions told us not to add and we correctly ignored).  

3. The different user groups discussed in '2' means the docker user has read-only access to cwl_ica_user's conda envs. This is partially resolved with https://github.com/umccr/cwl-ica-cli/pull/112, however we also don't have write-access to any of the root user's conda envs and at least one env MUST be writable.  We can set CONDA_ENVS_PATH to a tmpdir that the user does have access to. However, this workaround then means conda cannot find the cwl-ica or cwltool-icav1 environments owned by the cwl_ica_user user.  After creating the tmp CONDA_ENVS_PATH directory, we must then softlink these environments into the docker user's new tmp environment.  To make sure that cwl-ica is called from the writable CONDA_ENVS_PATH, we then also prefix all of the downstream cwl-ica calls with 'conda run --name cwl-ica'

