### PR TITLE
ramMin allocations for HiMem medium were incorrect

### DIFF
--- a/.github/catalogue/docs/tools/umccrise/2.2.0--0/umccrise__2.2.0--0.md
+++ b/.github/catalogue/docs/tools/umccrise/2.2.0--0/umccrise__2.2.0--0.md
@@ -17,7 +17,7 @@ umccrise 2.2.0--0 tool
 
   
 > ID: umccrise--2.2.0--0  
-> md5sum: 1597fab10fd044ee952dfbbb62bc94c3
+> md5sum: 6d0a765b8a2bf6639955d3e6d07be31f
 
 ### umccrise v(2.2.0--0) documentation
   
@@ -191,7 +191,7 @@ The output directory containing the umccrise data
 
   
 **workflow name:** umccrise_prod-wf  
-**wfl version name:** 2.2.0--0--75e015e  
+**wfl version name:** 2.2.0--0--052b3fa  
 
   
 

--- a/.github/catalogue/docs/tools/umccrise/2.2.1--0/umccrise__2.2.1--0.md
+++ b/.github/catalogue/docs/tools/umccrise/2.2.1--0/umccrise__2.2.1--0.md
@@ -17,7 +17,7 @@ umccrise 2.2.1--0 tool
 
   
 > ID: umccrise--2.2.1--0  
-> md5sum: 54826a10445b7234c8d2c2101487c767
+> md5sum: bf117cdda26ddb7e9f08f724820233d9
 
 ### umccrise v(2.2.1--0) documentation
   
@@ -191,7 +191,7 @@ The output directory containing the umccrise data
 
   
 **workflow name:** umccrise_prod-wf  
-**wfl version name:** 2.2.1--0--75e015e  
+**wfl version name:** 2.2.1--0--052b3fa  
 
   
 

--- a/.github/catalogue/docs/workflows/umccrise-with-dragen-germline-pipeline/2.2.0--3.9.3/umccrise-with-dragen-germline-pipeline__2.2.0--3.9.3.md
+++ b/.github/catalogue/docs/workflows/umccrise-with-dragen-germline-pipeline/2.2.0--3.9.3/umccrise-with-dragen-germline-pipeline__2.2.0--3.9.3.md
@@ -19,7 +19,7 @@ umccrise-with-dragen-germline-pipeline 2.2.0--3.9.3 workflow
 
   
 > ID: umccrise-with-dragen-germline-pipeline--2.2.0--3.9.3  
-> md5sum: ea9a9e25e578d4d95acabf77a7d6848b
+> md5sum: 4f9069b359782fd804a69309bb7a1db1
 
 ### umccrise-with-dragen-germline-pipeline v(2.2.0--3.9.3) documentation
   
@@ -300,7 +300,7 @@ The output directory containing all umccrise output files
 
   
 **workflow name:** umccrise-with-dragen-germline-pipeline_prod-wf  
-**wfl version name:** 2.2.0--3.9.3--40e48c4  
+**wfl version name:** 2.2.0--3.9.3--052b3fa  
 
   
 

--- a/.github/catalogue/docs/workflows/umccrise-with-dragen-germline-pipeline/2.2.1--3.9.3/umccrise-with-dragen-germline-pipeline__2.2.1--3.9.3.md
+++ b/.github/catalogue/docs/workflows/umccrise-with-dragen-germline-pipeline/2.2.1--3.9.3/umccrise-with-dragen-germline-pipeline__2.2.1--3.9.3.md
@@ -19,7 +19,7 @@ umccrise-with-dragen-germline-pipeline 2.2.1--3.9.3 workflow
 
   
 > ID: umccrise-with-dragen-germline-pipeline--2.2.1--3.9.3  
-> md5sum: c597d229dcb6ec4eb07acb3edcd1ee17
+> md5sum: 187ba7b5d8dbe8fa9a7e029305d1eab3
 
 ### umccrise-with-dragen-germline-pipeline v(2.2.1--3.9.3) documentation
   
@@ -300,7 +300,7 @@ The output directory containing all umccrise output files
 
   
 **workflow name:** umccrise-with-dragen-germline-pipeline_prod-wf  
-**wfl version name:** 2.2.1--3.9.3--40e48c4  
+**wfl version name:** 2.2.1--3.9.3--052b3fa  
 
   
 

--- a/.github/catalogue/images/workflows/umccrise-with-dragen-germline-pipeline/2.2.0--3.9.3/umccrise-with-dragen-germline-pipeline__2.2.0--3.9.3.svg
+++ b/.github/catalogue/images/workflows/umccrise-with-dragen-germline-pipeline/2.2.0--3.9.3/umccrise-with-dragen-germline-pipeline__2.2.0--3.9.3.svg
@@ -74,13 +74,13 @@
 <text text-anchor="middle" x="1209" y="-840.21" font-family="Times,serif" font-size="14.00">fastq_list_rows_germline</text>
 </g>
 <!-- fastq_list_rows_germline&#45;&gt;run_umccrise_pipeline_step -->
-<g id="edge8" class="edge">
+<g id="edge9" class="edge">
 <title>fastq_list_rows_germline&#45;&gt;run_umccrise_pipeline_step</title>
 <path fill="none" stroke="black" d="M1209,-825.27C1209,-747.62 1209,-435.78 1209,-340.62"/>
 <polygon fill="black" stroke="black" points="1212.5,-340.61 1209,-330.61 1205.5,-340.61 1212.5,-340.61"/>
 </g>
 <!-- fastq_list_rows_germline&#45;&gt;run_dragen_germline_pipeline_step -->
-<g id="edge9" class="edge">
+<g id="edge8" class="edge">
 <title>fastq_list_rows_germline&#45;&gt;run_dragen_germline_pipeline_step</title>
 <path fill="none" stroke="black" d="M1176.37,-825.32C1115.38,-792.45 984.22,-721.77 916.84,-685.45"/>
 <polygon fill="black" stroke="black" points="918.23,-682.23 907.77,-680.56 914.91,-688.39 918.23,-682.23"/>
@@ -182,13 +182,13 @@
 <polygon fill="black" stroke="black" points="1120.62,-333.23 1129.79,-327.93 1119.32,-326.36 1120.62,-333.23"/>
 </g>
 <!-- run_umccrise_pipeline_step&#45;&gt;umccrise_output_directory -->
-<g id="edge3" class="edge">
+<g id="edge4" class="edge">
 <title>run_umccrise_pipeline_step&#45;&gt;umccrise_output_directory</title>
 <path fill="none" stroke="black" d="M1209,-293.37C1209,-263.32 1209,-201.76 1209,-165.78"/>
 <polygon fill="black" stroke="black" points="1212.5,-165.49 1209,-155.49 1205.5,-165.49 1212.5,-165.49"/>
 </g>
 <!-- run_dragen_germline_pipeline_step&#45;&gt;run_umccrise_pipeline_step -->
-<g id="edge4" class="edge">
+<g id="edge3" class="edge">
 <title>run_dragen_germline_pipeline_step&#45;&gt;run_umccrise_pipeline_step</title>
 <path fill="none" stroke="black" d="M892.02,-643.17C947.08,-585.81 1120.48,-405.14 1184.73,-338.19"/>
 <polygon fill="black" stroke="black" points="1187.61,-340.24 1192.01,-330.61 1182.56,-335.4 1187.61,-340.24"/>

--- a/config/project.yaml
+++ b/config/project.yaml
@@ -320,12 +320,12 @@ projects:
           - name: 2.2.0--0
             path: 2.2.0--0/umccrise__2.2.0--0.cwl
             ica_workflow_version_name: 2.2.0--0
-            modification_time: 2023-01-12T02:36:12UTC
+            modification_time: 2023-01-26T23:48:47UTC
             run_instances: []
           - name: 2.2.1--0
             path: 2.2.1--0/umccrise__2.2.1--0.cwl
             ica_workflow_version_name: 2.2.1--0
-            modification_time: 2023-01-12T02:36:13UTC
+            modification_time: 2023-01-26T23:48:51UTC
             run_instances: []
       - name: dragen-somatic
         path: dragen-somatic
@@ -778,12 +778,12 @@ projects:
           - name: 2.2.0--3.9.3
             path: 2.2.0--3.9.3/umccrise-with-dragen-germline-pipeline__2.2.0--3.9.3.cwl
             ica_workflow_version_name: 2.2.0--3.9.3
-            modification_time: 2023-01-16T00:55:32UTC
+            modification_time: 2023-01-27T00:12:11UTC
             run_instances: []
           - name: 2.2.1--3.9.3
             path: 2.2.1--3.9.3/umccrise-with-dragen-germline-pipeline__2.2.1--3.9.3.cwl
             ica_workflow_version_name: 2.2.1--3.9.3
-            modification_time: 2023-01-16T00:55:35UTC
+            modification_time: 2023-01-27T00:12:14UTC
             run_instances: []
       - name: ghif-qc
         path: ghif-qc
@@ -1135,6 +1135,16 @@ projects:
             path: 2.2.1--0/umccrise__2.2.1--0.cwl
             ica_workflow_version_name: 2.2.1--0--75e015e
             modification_time: 2023-01-12T02:37:22UTC
+            run_instances: []
+          - name: 2.2.0--0
+            path: 2.2.0--0/umccrise__2.2.0--0.cwl
+            ica_workflow_version_name: 2.2.0--0--052b3fa
+            modification_time: 2023-01-26T23:49:22UTC
+            run_instances: []
+          - name: 2.2.1--0
+            path: 2.2.1--0/umccrise__2.2.1--0.cwl
+            ica_workflow_version_name: 2.2.1--0--052b3fa
+            modification_time: 2023-01-26T23:49:24UTC
             run_instances: []
     workflows:
       - name: tso500-ctdna
@@ -2341,6 +2351,16 @@ projects:
             path: 2.1.1--3.9.3/umccrise-with-dragen-germline-pipeline__2.1.1--3.9.3.cwl
             ica_workflow_version_name: 2.1.1--3.9.3--40e48c4
             modification_time: 2023-01-16T00:57:01UTC
+            run_instances: []
+          - name: 2.2.0--3.9.3
+            path: 2.2.0--3.9.3/umccrise-with-dragen-germline-pipeline__2.2.0--3.9.3.cwl
+            ica_workflow_version_name: 2.2.0--3.9.3--052b3fa
+            modification_time: 2023-01-27T00:12:49UTC
+            run_instances: []
+          - name: 2.2.1--3.9.3
+            path: 2.2.1--3.9.3/umccrise-with-dragen-germline-pipeline__2.2.1--3.9.3.cwl
+            ica_workflow_version_name: 2.2.1--3.9.3--052b3fa
+            modification_time: 2023-01-27T00:12:52UTC
             run_instances: []
       - name: dragen-pon-qc
         path: dragen-pon-qc

--- a/config/tool.yaml
+++ b/config/tool.yaml
@@ -359,10 +359,10 @@ tools:
         md5sum: 6f20fd7668e6f9408a5efe966cc16ce7
       - name: 2.2.0--0
         path: 2.2.0--0/umccrise__2.2.0--0.cwl
-        md5sum: 1597fab10fd044ee952dfbbb62bc94c3
+        md5sum: 6d0a765b8a2bf6639955d3e6d07be31f
       - name: 2.2.1--0
         path: 2.2.1--0/umccrise__2.2.1--0.cwl
-        md5sum: 54826a10445b7234c8d2c2101487c767
+        md5sum: bf117cdda26ddb7e9f08f724820233d9
     categories: []
   - name: custom-create-umccr-dragen-refdata-tarball-from-illumina-tar
     path: custom-create-umccr-dragen-refdata-tarball-from-illumina-tar

--- a/config/workflow.yaml
+++ b/config/workflow.yaml
@@ -163,10 +163,10 @@ workflows:
         md5sum: b0639c540d1cc9115b4f06156cd78fc1
       - name: 2.2.0--3.9.3
         path: 2.2.0--3.9.3/umccrise-with-dragen-germline-pipeline__2.2.0--3.9.3.cwl
-        md5sum: ea9a9e25e578d4d95acabf77a7d6848b
+        md5sum: 4f9069b359782fd804a69309bb7a1db1
       - name: 2.2.1--3.9.3
         path: 2.2.1--3.9.3/umccrise-with-dragen-germline-pipeline__2.2.1--3.9.3.cwl
-        md5sum: c597d229dcb6ec4eb07acb3edcd1ee17
+        md5sum: 187ba7b5d8dbe8fa9a7e029305d1eab3
     categories: []
   - name: ghif-qc
     path: ghif-qc

--- a/tools/umccrise/2.2.0--0/umccrise__2.2.0--0.cwl
+++ b/tools/umccrise/2.2.0--0/umccrise__2.2.0--0.cwl
@@ -29,7 +29,7 @@ hints:
         ilmn-tes:resources/type: standardHiMem
         ilmn-tes:resources/size: medium
         coresMin: 16
-        ramMin: 50000
+        ramMin: 128000
     DockerRequirement:
         dockerPull: 843407916570.dkr.ecr.ap-southeast-2.amazonaws.com/umccrise:2.2.0-fcef79d982
 

--- a/tools/umccrise/2.2.1--0/umccrise__2.2.1--0.cwl
+++ b/tools/umccrise/2.2.1--0/umccrise__2.2.1--0.cwl
@@ -29,7 +29,7 @@ hints:
         ilmn-tes:resources/type: standardHiMem
         ilmn-tes:resources/size: medium
         coresMin: 16
-        ramMin: 50000
+        ramMin: 128000
     DockerRequirement:
         dockerPull: 843407916570.dkr.ecr.ap-southeast-2.amazonaws.com/umccrise:2.2.1-8f677de0b9
 


### PR DESCRIPTION
Resolves #239.  

No actual changes required, for some reason had thought standard HiMem medium used 50 Gb but actually uses 128 Gb.  

UMCCRise currently efficiently uses the resources allocated