### PR TITLE
Specified different input directories for the somatic and germline inputs

### DIFF
--- a/.github/catalogue/docs/tools/umccrise/2.2.0--0/umccrise__2.2.0--0.md
+++ b/.github/catalogue/docs/tools/umccrise/2.2.0--0/umccrise__2.2.0--0.md
@@ -17,7 +17,7 @@ umccrise 2.2.0--0 tool
 
   
 > ID: umccrise--2.2.0--0  
-> md5sum: 6d0a765b8a2bf6639955d3e6d07be31f
+> md5sum: fa47b203d08df618f3b78cb3d540a645
 
 ### umccrise v(2.2.0--0) documentation
   
@@ -34,6 +34,7 @@ Documentation for umccrise v2.2.0--0
 
 ### Used By
   
+- [umccrise-pipeline 2.2.0--0](../../../workflows/umccrise-pipeline/2.2.0--0/umccrise-pipeline__2.2.0--0.md)  
 - [umccrise-with-dragen-germline-pipeline 2.2.0--3.9.3](../../../workflows/umccrise-with-dragen-germline-pipeline/2.2.0--3.9.3/umccrise-with-dragen-germline-pipeline__2.2.0--3.9.3.md)  
 
   
@@ -61,7 +62,7 @@ The dragen germline directory
   
 > ID: dragen_normal_id
   
-**Optional:** `False`  
+**Optional:** `True`  
 **Type:** `string`  
 **Docs:**  
 The name of the dragen normal sample
@@ -87,7 +88,7 @@ The dragen somatic directory
   
 > ID: dragen_tumor_id
   
-**Optional:** `False`  
+**Optional:** `True`  
 **Type:** `string`  
 **Docs:**  
 The name of the dragen tumor sample
@@ -191,7 +192,7 @@ The output directory containing the umccrise data
 
   
 **workflow name:** umccrise_prod-wf  
-**wfl version name:** 2.2.0--0--052b3fa  
+**wfl version name:** 2.2.0--0--b64c6f3  
 
   
 

--- a/.github/catalogue/docs/tools/umccrise/2.2.1--0/umccrise__2.2.1--0.md
+++ b/.github/catalogue/docs/tools/umccrise/2.2.1--0/umccrise__2.2.1--0.md
@@ -17,7 +17,7 @@ umccrise 2.2.1--0 tool
 
   
 > ID: umccrise--2.2.1--0  
-> md5sum: bf117cdda26ddb7e9f08f724820233d9
+> md5sum: 4ad97bfb3f5b7ef1b2bca70a4aa789ee
 
 ### umccrise v(2.2.1--0) documentation
   
@@ -34,6 +34,7 @@ Documentation for umccrise v2.2.1--0
 
 ### Used By
   
+- [umccrise-pipeline 2.2.1--0](../../../workflows/umccrise-pipeline/2.2.1--0/umccrise-pipeline__2.2.1--0.md)  
 - [umccrise-with-dragen-germline-pipeline 2.2.1--3.9.3](../../../workflows/umccrise-with-dragen-germline-pipeline/2.2.1--3.9.3/umccrise-with-dragen-germline-pipeline__2.2.1--3.9.3.md)  
 
   
@@ -61,7 +62,7 @@ The dragen germline directory
   
 > ID: dragen_normal_id
   
-**Optional:** `False`  
+**Optional:** `True`  
 **Type:** `string`  
 **Docs:**  
 The name of the dragen normal sample
@@ -87,7 +88,7 @@ The dragen somatic directory
   
 > ID: dragen_tumor_id
   
-**Optional:** `False`  
+**Optional:** `True`  
 **Type:** `string`  
 **Docs:**  
 The name of the dragen tumor sample
@@ -191,7 +192,7 @@ The output directory containing the umccrise data
 
   
 **workflow name:** umccrise_prod-wf  
-**wfl version name:** 2.2.1--0--052b3fa  
+**wfl version name:** 2.2.1--0--b64c6f3  
 
   
 

--- a/.github/catalogue/docs/workflows/umccrise-pipeline/2.2.0--0/umccrise-pipeline__2.2.0--0.md
+++ b/.github/catalogue/docs/workflows/umccrise-pipeline/2.2.0--0/umccrise-pipeline__2.2.0--0.md
@@ -19,7 +19,7 @@ umccrise-pipeline 2.2.0--0 workflow
 
   
 > ID: umccrise-pipeline--2.2.0--0  
-> md5sum: 3f9bb9bf72fbd9cc3534649a43c8b88b
+> md5sum: e100db1a3f320994e318a8d8e07412f9
 
 ### umccrise-pipeline v(2.2.0--0) documentation
   

--- a/.github/catalogue/docs/workflows/umccrise-pipeline/2.2.1--0/umccrise-pipeline__2.2.1--0.md
+++ b/.github/catalogue/docs/workflows/umccrise-pipeline/2.2.1--0/umccrise-pipeline__2.2.1--0.md
@@ -19,7 +19,7 @@ umccrise-pipeline 2.2.1--0 workflow
 
   
 > ID: umccrise-pipeline--2.2.1--0  
-> md5sum: 21c76209280de8f88446a1dd1064889a
+> md5sum: d9dfc8efd650e4c52c074ed7855bd5aa
 
 ### umccrise-pipeline v(2.2.1--0) documentation
   

--- a/.github/catalogue/docs/workflows/umccrise-with-dragen-germline-pipeline/2.2.0--3.9.3/umccrise-with-dragen-germline-pipeline__2.2.0--3.9.3.md
+++ b/.github/catalogue/docs/workflows/umccrise-with-dragen-germline-pipeline/2.2.0--3.9.3/umccrise-with-dragen-germline-pipeline__2.2.0--3.9.3.md
@@ -19,7 +19,7 @@ umccrise-with-dragen-germline-pipeline 2.2.0--3.9.3 workflow
 
   
 > ID: umccrise-with-dragen-germline-pipeline--2.2.0--3.9.3  
-> md5sum: fee63a2d495c801b6ba1b88e5fc32173
+> md5sum: 6520f297089f46c1f4c44ecf1b8dd1fc
 
 ### umccrise-with-dragen-germline-pipeline v(2.2.0--3.9.3) documentation
   
@@ -300,7 +300,7 @@ The output directory containing all umccrise output files
 
   
 **workflow name:** umccrise-with-dragen-germline-pipeline_prod-wf  
-**wfl version name:** 2.2.0--3.9.3--6eacfb8  
+**wfl version name:** 2.2.0--3.9.3--b64c6f3  
 
   
 

--- a/.github/catalogue/docs/workflows/umccrise-with-dragen-germline-pipeline/2.2.1--3.9.3/umccrise-with-dragen-germline-pipeline__2.2.1--3.9.3.md
+++ b/.github/catalogue/docs/workflows/umccrise-with-dragen-germline-pipeline/2.2.1--3.9.3/umccrise-with-dragen-germline-pipeline__2.2.1--3.9.3.md
@@ -19,7 +19,7 @@ umccrise-with-dragen-germline-pipeline 2.2.1--3.9.3 workflow
 
   
 > ID: umccrise-with-dragen-germline-pipeline--2.2.1--3.9.3  
-> md5sum: 9080034ffc1a02990e4eaffb45f556d6
+> md5sum: 83634d8aa468e9a7636c63c9e48ddd34
 
 ### umccrise-with-dragen-germline-pipeline v(2.2.1--3.9.3) documentation
   
@@ -300,7 +300,7 @@ The output directory containing all umccrise output files
 
   
 **workflow name:** umccrise-with-dragen-germline-pipeline_prod-wf  
-**wfl version name:** 2.2.1--3.9.3--6eacfb8  
+**wfl version name:** 2.2.1--3.9.3--b64c6f3  
 
   
 

--- a/.github/catalogue/images/workflows/umccrise-with-dragen-germline-pipeline/2.2.0--3.9.3/umccrise-with-dragen-germline-pipeline__2.2.0--3.9.3.svg
+++ b/.github/catalogue/images/workflows/umccrise-with-dragen-germline-pipeline/2.2.0--3.9.3/umccrise-with-dragen-germline-pipeline__2.2.0--3.9.3.svg
@@ -74,13 +74,13 @@
 <text text-anchor="middle" x="1209" y="-840.21" font-family="Times,serif" font-size="14.00">fastq_list_rows_germline</text>
 </g>
 <!-- fastq_list_rows_germline&#45;&gt;run_umccrise_pipeline_step -->
-<g id="edge8" class="edge">
+<g id="edge9" class="edge">
 <title>fastq_list_rows_germline&#45;&gt;run_umccrise_pipeline_step</title>
 <path fill="none" stroke="black" d="M1209,-825.27C1209,-747.62 1209,-435.78 1209,-340.62"/>
 <polygon fill="black" stroke="black" points="1212.5,-340.61 1209,-330.61 1205.5,-340.61 1212.5,-340.61"/>
 </g>
 <!-- fastq_list_rows_germline&#45;&gt;run_dragen_germline_pipeline_step -->
-<g id="edge9" class="edge">
+<g id="edge8" class="edge">
 <title>fastq_list_rows_germline&#45;&gt;run_dragen_germline_pipeline_step</title>
 <path fill="none" stroke="black" d="M1176.37,-825.32C1115.38,-792.45 984.22,-721.77 916.84,-685.45"/>
 <polygon fill="black" stroke="black" points="918.23,-682.23 907.77,-680.56 914.91,-688.39 918.23,-682.23"/>
@@ -182,13 +182,13 @@
 <polygon fill="black" stroke="black" points="1120.62,-333.23 1129.79,-327.93 1119.32,-326.36 1120.62,-333.23"/>
 </g>
 <!-- run_umccrise_pipeline_step&#45;&gt;umccrise_output_directory -->
-<g id="edge3" class="edge">
+<g id="edge4" class="edge">
 <title>run_umccrise_pipeline_step&#45;&gt;umccrise_output_directory</title>
 <path fill="none" stroke="black" d="M1209,-293.37C1209,-263.32 1209,-201.76 1209,-165.78"/>
 <polygon fill="black" stroke="black" points="1212.5,-165.49 1209,-155.49 1205.5,-165.49 1212.5,-165.49"/>
 </g>
 <!-- run_dragen_germline_pipeline_step&#45;&gt;run_umccrise_pipeline_step -->
-<g id="edge4" class="edge">
+<g id="edge3" class="edge">
 <title>run_dragen_germline_pipeline_step&#45;&gt;run_umccrise_pipeline_step</title>
 <path fill="none" stroke="black" d="M892.02,-643.17C947.08,-585.81 1120.48,-405.14 1184.73,-338.19"/>
 <polygon fill="black" stroke="black" points="1187.61,-340.24 1192.01,-330.61 1182.56,-335.4 1187.61,-340.24"/>

--- a/config/project.yaml
+++ b/config/project.yaml
@@ -748,12 +748,12 @@ projects:
           - name: 2.2.0--0
             path: 2.2.0--0/umccrise-pipeline__2.2.0--0.cwl
             ica_workflow_version_name: 2.2.0--0
-            modification_time: 2023-03-29T22:02:50UTC
+            modification_time: 2023-03-30T22:43:55UTC
             run_instances: []
           - name: 2.2.1--0
             path: 2.2.1--0/umccrise-pipeline__2.2.1--0.cwl
             ica_workflow_version_name: 2.2.1--0
-            modification_time: 2023-02-01T23:56:03UTC
+            modification_time: 2023-03-30T22:46:10UTC
             run_instances: []
       - name: tso500-ctdna-with-post-processing-pipeline
         path: tso500-ctdna-with-post-processing-pipeline

--- a/config/project.yaml
+++ b/config/project.yaml
@@ -803,7 +803,7 @@ projects:
           - name: 2.2.1--3.9.3
             path: 2.2.1--3.9.3/umccrise-with-dragen-germline-pipeline__2.2.1--3.9.3.cwl
             ica_workflow_version_name: 2.2.1--3.9.3
-            modification_time: 2023-03-14T23:59:29UTC
+            modification_time: 2023-03-31T05:02:48UTC
             run_instances: []
       - name: ghif-qc
         path: ghif-qc
@@ -1200,6 +1200,16 @@ projects:
             path: 2.2.1--0/umccrise__2.2.1--0.cwl
             ica_workflow_version_name: 2.2.1--0--052b3fa
             modification_time: 2023-01-26T23:49:24UTC
+            run_instances: []
+          - name: 2.2.0--0
+            path: 2.2.0--0/umccrise__2.2.0--0.cwl
+            ica_workflow_version_name: 2.2.0--0--b64c6f3
+            modification_time: 2023-03-31T04:40:33UTC
+            run_instances: []
+          - name: 2.2.1--0
+            path: 2.2.1--0/umccrise__2.2.1--0.cwl
+            ica_workflow_version_name: 2.2.1--0--b64c6f3
+            modification_time: 2023-03-31T04:40:36UTC
             run_instances: []
     workflows:
       - name: tso500-ctdna
@@ -2696,6 +2706,16 @@ projects:
             path: 2.2.1--3.9.3/umccrise-with-dragen-germline-pipeline__2.2.1--3.9.3.cwl
             ica_workflow_version_name: 2.2.1--3.9.3--6eacfb8
             modification_time: 2023-03-15T00:00:32UTC
+            run_instances: []
+          - name: 2.2.0--3.9.3
+            path: 2.2.0--3.9.3/umccrise-with-dragen-germline-pipeline__2.2.0--3.9.3.cwl
+            ica_workflow_version_name: 2.2.0--3.9.3--b64c6f3
+            modification_time: 2023-03-31T05:03:27UTC
+            run_instances: []
+          - name: 2.2.1--3.9.3
+            path: 2.2.1--3.9.3/umccrise-with-dragen-germline-pipeline__2.2.1--3.9.3.cwl
+            ica_workflow_version_name: 2.2.1--3.9.3--b64c6f3
+            modification_time: 2023-03-31T05:03:31UTC
             run_instances: []
       - name: dragen-pon-qc
         path: dragen-pon-qc

--- a/config/project.yaml
+++ b/config/project.yaml
@@ -320,7 +320,7 @@ projects:
           - name: 2.2.0--0
             path: 2.2.0--0/umccrise__2.2.0--0.cwl
             ica_workflow_version_name: 2.2.0--0
-            modification_time: 2023-03-07T00:58:11UTC
+            modification_time: 2023-03-30T22:36:47UTC
             run_instances: []
           - name: 2.2.1--0
             path: 2.2.1--0/umccrise__2.2.1--0.cwl

--- a/config/project.yaml
+++ b/config/project.yaml
@@ -325,7 +325,7 @@ projects:
           - name: 2.2.1--0
             path: 2.2.1--0/umccrise__2.2.1--0.cwl
             ica_workflow_version_name: 2.2.1--0
-            modification_time: 2023-01-26T23:48:51UTC
+            modification_time: 2023-03-30T22:35:57UTC
             run_instances: []
       - name: dragen-somatic
         path: dragen-somatic

--- a/config/tool.yaml
+++ b/config/tool.yaml
@@ -362,7 +362,7 @@ tools:
         md5sum: 6d0a765b8a2bf6639955d3e6d07be31f
       - name: 2.2.1--0
         path: 2.2.1--0/umccrise__2.2.1--0.cwl
-        md5sum: bf117cdda26ddb7e9f08f724820233d9
+        md5sum: 4ad97bfb3f5b7ef1b2bca70a4aa789ee
     categories: []
   - name: custom-create-umccr-dragen-refdata-tarball-from-illumina-tar
     path: custom-create-umccr-dragen-refdata-tarball-from-illumina-tar

--- a/config/tool.yaml
+++ b/config/tool.yaml
@@ -359,7 +359,7 @@ tools:
         md5sum: 6f20fd7668e6f9408a5efe966cc16ce7
       - name: 2.2.0--0
         path: 2.2.0--0/umccrise__2.2.0--0.cwl
-        md5sum: 6d0a765b8a2bf6639955d3e6d07be31f
+        md5sum: fa47b203d08df618f3b78cb3d540a645
       - name: 2.2.1--0
         path: 2.2.1--0/umccrise__2.2.1--0.cwl
         md5sum: 4ad97bfb3f5b7ef1b2bca70a4aa789ee

--- a/config/workflow.yaml
+++ b/config/workflow.yaml
@@ -159,10 +159,10 @@ workflows:
         md5sum: be349a39b3da4cf2facfed2b70ce90ec
       - name: 2.2.0--3.9.3
         path: 2.2.0--3.9.3/umccrise-with-dragen-germline-pipeline__2.2.0--3.9.3.cwl
-        md5sum: fee63a2d495c801b6ba1b88e5fc32173
+        md5sum: 6520f297089f46c1f4c44ecf1b8dd1fc
       - name: 2.2.1--3.9.3
         path: 2.2.1--3.9.3/umccrise-with-dragen-germline-pipeline__2.2.1--3.9.3.cwl
-        md5sum: 9080034ffc1a02990e4eaffb45f556d6
+        md5sum: 83634d8aa468e9a7636c63c9e48ddd34
     categories: []
   - name: ghif-qc
     path: ghif-qc

--- a/config/workflow.yaml
+++ b/config/workflow.yaml
@@ -126,10 +126,10 @@ workflows:
         md5sum: 23e0df54d3a6ddaa46a9712add1218a9
       - name: 2.2.0--0
         path: 2.2.0--0/umccrise-pipeline__2.2.0--0.cwl
-        md5sum: 3f9bb9bf72fbd9cc3534649a43c8b88b
+        md5sum: e100db1a3f320994e318a8d8e07412f9
       - name: 2.2.1--0
         path: 2.2.1--0/umccrise-pipeline__2.2.1--0.cwl
-        md5sum: 21c76209280de8f88446a1dd1064889a
+        md5sum: d9dfc8efd650e4c52c074ed7855bd5aa
     categories: []
   - name: tso500-ctdna-with-post-processing-pipeline
     path: tso500-ctdna-with-post-processing-pipeline

--- a/tools/umccrise/2.2.0--0/umccrise__2.2.0--0.cwl
+++ b/tools/umccrise/2.2.0--0/umccrise__2.2.0--0.cwl
@@ -3,8 +3,8 @@ class: CommandLineTool
 
 # Extensions
 $namespaces:
-    s: https://schema.org/
-    ilmn-tes: https://platform.illumina.com/rdf/ica/
+  s: https://schema.org/
+  ilmn-tes: https://platform.illumina.com/rdf/ica/
 $schemas:
   - https://schema.org/version/latest/schemaorg-current-http.rdf
 
@@ -14,6 +14,12 @@ s:author:
     s:name: Peter Diakumis
     s:email: peter.diakumis@umccr.org
     s:identifier: https://orcid.org/0000-0002-7502-7545
+
+s:maintainer:
+  class: s:Person
+  s:name: Alexis Lucattini
+  s:email: Alexis.Lucattini@umccr.org
+  s:identifier: https://orcid.org/0000-0001-9754-647X
 
 # ID/Docs
 id: umccrise--2.2.0--0
@@ -84,6 +90,18 @@ requirements:
           */
           return get_scratch_mount() + "/" + "inputs";
         }
+      - var get_somatic_input_dir = function(){
+          /*
+          Get the inputs directory in /scratch space for the dragen somatic input
+          */
+          return get_scratch_input_dir() + "/" + "somatic" + "/" + inputs.dragen_somatic_directory.basename;
+        }
+      - var get_germline_input_dir = function(){
+          /*
+          Get the inputs directory in /scratch space for the dragen somatic input
+          */
+          return get_scratch_input_dir() + "/" + "germline" + "/" + inputs.dragen_germline_directory.basename;
+        }
       - var get_genomes_dir_name = function(){
           /*
           Return the stripped basename of the genomes tarball
@@ -133,16 +151,16 @@ requirements:
             --file "$(inputs.genomes_tar.path)"
 
           # Create input directories
-          mkdir -p "$(get_scratch_input_dir())/$(inputs.dragen_somatic_directory.basename)/"
-          mkdir -p "$(get_scratch_input_dir())/$(inputs.dragen_germline_directory.basename)/"
+          mkdir -p "$(get_somatic_input_dir())"
+          mkdir -p "$(get_germline_input_dir())"
 
           # Put inputs into scratch space
           echo "\$(date): Placing inputs into scratch space" 1>&2
-          cp -r "$(inputs.dragen_somatic_directory.path)/." "$(get_scratch_input_dir())/$(inputs.dragen_somatic_directory.basename)/"
-          cp -r "$(inputs.dragen_germline_directory.path)/." "$(get_scratch_input_dir())/$(inputs.dragen_germline_directory.basename)/"
+          cp -r "$(inputs.dragen_somatic_directory.path)/." "$(get_somatic_input_dir())"/"
+          cp -r "$(inputs.dragen_germline_directory.path)/." "$(get_germline_input_dir())/"
 
           # Run umccrise
-          echo "\$(date): Running UMCCrise" 1>&2
+          echo "\$(date): Running UMCCRise" 1>&2
           $(get_eval_umccrise_line())
 
           # Copy over working directory
@@ -175,7 +193,7 @@ inputs:
       prefix: "--dragen_somatic_dir"
       valueFrom: |
         ${
-          return get_scratch_input_dir() + "/" + self.basename;
+          return get_somatic_input_dir();
         }
   dragen_germline_directory:
     label: dragen germline directory
@@ -186,7 +204,7 @@ inputs:
       prefix: "--dragen_germline_dir"
       valueFrom: |
         ${
-          return get_scratch_input_dir() + "/" + self.basename;
+          return get_germline_input_dir();
         }
   genomes_tar:
     label: genomes tar
@@ -208,14 +226,14 @@ inputs:
     label: dragen tumor id
     doc: |
       The name of the dragen tumor sample
-    type: string
+    type: string?
     inputBinding:
       prefix: "--dragen_tumor_id"
   dragen_normal_id:
     label: dragen normal id
     doc: |
       The name of the dragen normal sample
-    type: string
+    type: string?
     inputBinding:
       prefix: "--dragen_normal_id"
   # Output names

--- a/tools/umccrise/2.2.1--0/umccrise__2.2.1--0.cwl
+++ b/tools/umccrise/2.2.1--0/umccrise__2.2.1--0.cwl
@@ -15,6 +15,12 @@ s:author:
     s:email: peter.diakumis@umccr.org
     s:identifier: https://orcid.org/0000-0002-7502-7545
 
+s:maintainer:
+  class: s:Person
+  s:name: Alexis Lucattini
+  s:email: Alexis.Lucattini@umccr.org
+  s:identifier: https://orcid.org/0000-0001-9754-647X
+
 # ID/Docs
 id: umccrise--2.2.1--0
 label: umccrise v(2.2.1--0)
@@ -86,7 +92,7 @@ requirements:
         }
       - var get_somatic_input_dir = function(){
           /*
-          Get the inputs directory in /scratch space for the dragen somatic input 
+          Get the inputs directory in /scratch space for the dragen somatic input
           */
           return get_scratch_input_dir() + "/" + "somatic" + "/" + inputs.dragen_somatic_directory.basename;
         }

--- a/tools/umccrise/2.2.1--0/umccrise__2.2.1--0.cwl
+++ b/tools/umccrise/2.2.1--0/umccrise__2.2.1--0.cwl
@@ -84,6 +84,18 @@ requirements:
           */
           return get_scratch_mount() + "/" + "inputs";
         }
+      - var get_somatic_input_dir = function(){
+          /*
+          Get the inputs directory in /scratch space for the dragen somatic input 
+          */
+          return get_scratch_input_dir() + "/" + "somatic" + "/" + inputs.dragen_somatic_directory.basename;
+        }
+      - var get_germline_input_dir = function(){
+          /*
+          Get the inputs directory in /scratch space for the dragen somatic input
+          */
+          return get_scratch_input_dir() + "/" + "germline" + "/" + inputs.dragen_germline_directory.basename;
+        }
       - var get_genomes_dir_name = function(){
           /*
           Return the stripped basename of the genomes tarball
@@ -133,16 +145,16 @@ requirements:
             --file "$(inputs.genomes_tar.path)"
 
           # Create input directories
-          mkdir -p "$(get_scratch_input_dir())/$(inputs.dragen_somatic_directory.basename)/"
-          mkdir -p "$(get_scratch_input_dir())/$(inputs.dragen_germline_directory.basename)/"
+          mkdir -p "$(get_somatic_input_dir())"
+          mkdir -p "$(get_germline_input_dir())"
 
           # Put inputs into scratch space
           echo "\$(date): Placing inputs into scratch space" 1>&2
-          cp -r "$(inputs.dragen_somatic_directory.path)/." "$(get_scratch_input_dir())/$(inputs.dragen_somatic_directory.basename)/"
-          cp -r "$(inputs.dragen_germline_directory.path)/." "$(get_scratch_input_dir())/$(inputs.dragen_germline_directory.basename)/"
+          cp -r "$(inputs.dragen_somatic_directory.path)/." "$(get_somatic_input_dir())"/"
+          cp -r "$(inputs.dragen_germline_directory.path)/." "$(get_germline_input_dir())/"
 
           # Run umccrise
-          echo "\$(date): Running UMCCrise" 1>&2
+          echo "\$(date): Running UMCCRise" 1>&2
           $(get_eval_umccrise_line())
 
           # Copy over working directory
@@ -175,7 +187,7 @@ inputs:
       prefix: "--dragen_somatic_dir"
       valueFrom: |
         ${
-          return get_scratch_input_dir() + "/" + self.basename;
+          return get_somatic_input_dir();
         }
   dragen_germline_directory:
     label: dragen germline directory
@@ -186,7 +198,7 @@ inputs:
       prefix: "--dragen_germline_dir"
       valueFrom: |
         ${
-          return get_scratch_input_dir() + "/" + self.basename;
+          return get_germline_input_dir();
         }
   genomes_tar:
     label: genomes tar
@@ -208,14 +220,14 @@ inputs:
     label: dragen tumor id
     doc: |
       The name of the dragen tumor sample
-    type: string
+    type: string?
     inputBinding:
       prefix: "--dragen_tumor_id"
   dragen_normal_id:
     label: dragen normal id
     doc: |
       The name of the dragen normal sample
-    type: string
+    type: string?
     inputBinding:
       prefix: "--dragen_normal_id"
   # Output names


### PR DESCRIPTION
This prevents a nameclash if the basename for the germline and somatic directories are the same.

Also made inputs for tumor and normal ids optional

Fixes #311 and #312

Will eventually move these functions to a typescript directory (just as an FYI)