### PR TITLE
umccrise v2.3.1 tool def

### DIFF
--- a/.github/catalogue/docs/tools/umccrise/2.3.1--1/umccrise__2.3.1--1.md
+++ b/.github/catalogue/docs/tools/umccrise/2.3.1--1/umccrise__2.3.1--1.md
@@ -1,0 +1,244 @@
+
+umccrise 2.3.1--1 tool
+======================
+
+## Table of Contents
+  
+- [Overview](#umccrise-v231--1-overview)  
+- [Links](#related-links)  
+- [Inputs](#umccrise-v231--1-inputs)  
+- [Outputs](#umccrise-v231--1-outputs)  
+- [ICA](#ica)  
+
+
+## umccrise v(2.3.1--1) Overview
+
+
+
+  
+> ID: umccrise--2.3.1--1  
+> md5sum: 6cbf94c19b9e73fbdf33ee3300980d70
+
+### umccrise v(2.3.1--1) documentation
+  
+Documentation for umccrise v2.3.1--1
+
+### Categories
+  
+
+
+## Related Links
+  
+- [CWL File Path](../../../../../../tools/umccrise/2.3.1--1/umccrise__2.3.1--1.cwl)  
+
+  
+
+
+## umccrise v(2.3.1--1) Inputs
+
+### debug
+
+
+
+  
+> ID: debug
+  
+**Optional:** `True`  
+**Type:** `boolean`  
+**Docs:**  
+Copy workspace to output directory if workflow fails
+
+
+### dragen germline directory
+
+
+
+  
+> ID: dragen_germline_directory
+  
+**Optional:** `False`  
+**Type:** `Directory`  
+**Docs:**  
+The dragen germline directory
+
+
+### dragen normal id
+
+
+
+  
+> ID: dragen_normal_id
+  
+**Optional:** `True`  
+**Type:** `string`  
+**Docs:**  
+The name of the dragen normal sample
+
+
+### dragen somatic directory
+
+
+
+  
+> ID: dragen_somatic_directory
+  
+**Optional:** `False`  
+**Type:** `Directory`  
+**Docs:**  
+The dragen somatic directory
+
+
+### dragen tumor id
+
+
+
+  
+> ID: dragen_tumor_id
+  
+**Optional:** `True`  
+**Type:** `string`  
+**Docs:**  
+The name of the dragen tumor sample
+
+
+### dry run
+
+
+
+  
+> ID: dry_run
+  
+**Optional:** `True`  
+**Type:** `boolean`  
+**Docs:**  
+Prints rules and commands to be run without actually executing them
+
+
+### genomes tar
+
+
+
+  
+> ID: genomes_tar
+  
+**Optional:** `False`  
+**Type:** `File`  
+**Docs:**  
+The reference umccrise tarball
+
+
+### include stage
+
+
+
+  
+> ID: include_stage
+  
+**Optional:** `True`  
+**Type:** `.[]`  
+**Docs:**  
+Optionally, specify stage(s) to run
+
+
+### output directory name
+
+
+
+  
+> ID: output_directory_name
+  
+**Optional:** `False`  
+**Type:** `string`  
+**Docs:**  
+The name of the output directory
+
+
+### skip stage
+
+
+
+  
+> ID: skip_stage
+  
+**Optional:** `True`  
+**Type:** `.[]`  
+**Docs:**  
+Runs all default stage(s) excluding the one selected
+
+
+### subject identifier
+
+
+
+  
+> ID: subject_identifier
+  
+**Optional:** `False`  
+**Type:** `string`  
+**Docs:**  
+The subject ID (used to name output files)
+
+
+### threads
+
+
+
+  
+> ID: threads
+  
+**Optional:** `True`  
+**Type:** `int`  
+**Docs:**  
+Number of threads to use
+
+  
+
+
+## umccrise v(2.3.1--1) Outputs
+
+### output directory
+
+
+
+  
+> ID: umccrise--2.3.1--1/output_directory  
+
+  
+**Optional:** `False`  
+**Output Type:** `Directory`  
+**Docs:**  
+The output directory containing the umccrise data
+  
+
+  
+
+
+## ICA
+
+### ToC
+  
+- [development_workflows](#project-development_workflows)  
+- [production_workflows](#project-production_workflows)  
+
+
+### Project: development_workflows
+
+
+> wfl id: wfl.af61d2b172e84cbfa85eaf184226db8b  
+
+  
+**workflow name:** umccrise_dev-wf  
+**wfl version name:** 2.3.1--1  
+
+
+### Project: production_workflows
+
+
+> wfl id: wfl.714e9172f3674023b210ccc7c47db05a  
+
+  
+**workflow name:** umccrise_prod-wf  
+**wfl version name:** 2.3.1--1--9344851  
+
+  
+

--- a/config/project.yaml
+++ b/config/project.yaml
@@ -352,6 +352,11 @@ projects:
             ica_workflow_version_name: 2.3.0--0
             modification_time: 2023-05-15T04:27:57UTC
             run_instances: []
+          - name: 2.3.1--1
+            path: 2.3.1--1/umccrise__2.3.1--1.cwl
+            ica_workflow_version_name: 2.3.1--1
+            modification_time: 2023-09-13T13:24:08UTC
+            run_instances: []
       - name: dragen-somatic
         path: dragen-somatic
         ica_workflow_name: dragen-somatic_dev-wf
@@ -1375,6 +1380,11 @@ projects:
             path: 2.3.0--0/umccrise__2.3.0--0.cwl
             ica_workflow_version_name: 2.3.0--0--2990cf1
             modification_time: 2023-05-16T05:37:43UTC
+            run_instances: []
+          - name: 2.3.1--1
+            path: 2.3.1--1/umccrise__2.3.1--1.cwl
+            ica_workflow_version_name: 2.3.1--1--__GIT_COMMIT_ID__
+            modification_time:
             run_instances: []
     workflows:
       - name: tso500-ctdna

--- a/config/project.yaml
+++ b/config/project.yaml
@@ -1383,8 +1383,8 @@ projects:
             run_instances: []
           - name: 2.3.1--1
             path: 2.3.1--1/umccrise__2.3.1--1.cwl
-            ica_workflow_version_name: 2.3.1--1--__GIT_COMMIT_ID__
-            modification_time:
+            ica_workflow_version_name: 2.3.1--1--9344851
+            modification_time: 2023-09-13T23:40:12UTC
             run_instances: []
     workflows:
       - name: tso500-ctdna

--- a/config/tool.yaml
+++ b/config/tool.yaml
@@ -390,6 +390,9 @@ tools:
       - name: 2.3.0--0
         path: 2.3.0--0/umccrise__2.3.0--0.cwl
         md5sum: ab13fdc5b457f671f1891b8451721466
+      - name: 2.3.1--1
+        path: 2.3.1--1/umccrise__2.3.1--1.cwl
+        md5sum: 6cbf94c19b9e73fbdf33ee3300980d70
     categories: []
   - name: custom-create-umccr-dragen-refdata-tarball-from-illumina-tar
     path: custom-create-umccr-dragen-refdata-tarball-from-illumina-tar

--- a/cwl-ica-catalogue.md
+++ b/cwl-ica-catalogue.md
@@ -534,6 +534,7 @@ UMCCR CWL-ICA Catalogue
 - [2.2.0--0](.github/catalogue/docs/tools/umccrise/2.2.0--0/umccrise__2.2.0--0.md)  
 - [2.2.1--0](.github/catalogue/docs/tools/umccrise/2.2.1--0/umccrise__2.2.1--0.md)  
 - [2.3.0--0](.github/catalogue/docs/tools/umccrise/2.3.0--0/umccrise__2.3.0--0.md)  
+- [2.3.1--1](.github/catalogue/docs/tools/umccrise/2.3.1--1/umccrise__2.3.1--1.md)  
 
 
 ### custom-create-umccr-dragen-refdata-tarball-from-illumina-tar

--- a/tools/umccrise/2.3.1--1/umccrise__2.3.1--1.cwl
+++ b/tools/umccrise/2.3.1--1/umccrise__2.3.1--1.cwl
@@ -1,0 +1,267 @@
+cwlVersion: v1.1
+class: CommandLineTool
+
+# Extensions
+$namespaces:
+    s: https://schema.org/
+    ilmn-tes: https://platform.illumina.com/rdf/ica/
+$schemas:
+  - https://schema.org/version/latest/schemaorg-current-http.rdf
+
+# Metadata
+s:author:
+    class: s:Person
+    s:name: Peter Diakumis
+    s:email: peter.diakumis@umccr.org
+    s:identifier: https://orcid.org/0000-0002-7502-7545
+
+s:maintainer:
+  class: s:Person
+  s:name: Alexis Lucattini
+  s:email: Alexis.Lucattini@umccr.org
+  s:identifier: https://orcid.org/0000-0001-9754-647X
+
+# ID/Docs
+id: umccrise--2.3.1--1
+label: umccrise v(2.3.1--1)
+doc: |
+    Documentation for umccrise v2.3.1--1
+
+# ILMN V1 Resources Guide: https://illumina.gitbook.io/ica-v1/analysis/a-taskexecution#type-and-size
+# ILMN V2 Resources Guide: https://help.ica.illumina.com/project/p-flow/f-pipelines#compute-types
+hints:
+    ResourceRequirement:
+        ilmn-tes:resources/tier: standard
+        ilmn-tes:resources/type: standardHiMem
+        ilmn-tes:resources/size: medium
+        coresMin: 16
+        ramMin: 128000
+    DockerRequirement:
+        dockerPull: 843407916570.dkr.ecr.ap-southeast-2.amazonaws.com/umccrise:2.3.1-dbedb31757
+
+requirements:
+  InlineJavascriptRequirement:
+    expressionLib:
+      - $include: ../../../typescript-expressions/utils/1.0.0/utils__1.0.0.cwljs
+      - $include: ../../../typescript-expressions/umccrise/2.0.0/umccrise__2.0.0.cwljs
+  InitialWorkDirRequirement:
+    listing:
+      - entryname: "$(get_run_script_entryname())"
+        entry: |
+          #!/usr/bin/env bash
+
+          # Set to fail
+          set -euo pipefail
+
+          # Create a cleanup function for the trap command
+          cleanup(){
+            if [[ "$(get_bool_value_as_str(inputs.debug))" == "true" ]]; then
+              echo "\$(date): UMCCRise failed but debug set to true, copying over workspace into output directory" 1>&2
+              cp -r "$(get_scratch_working_dir(inputs.output_directory_name))/." "$(inputs.output_directory_name)/"
+            fi
+            exit 1
+          }
+
+          # Create parent dir for working tmp dir
+          echo "\$(date): Creating parent dir for workspace in scratch" 1>&2
+          mkdir -p "$(get_scratch_working_parent_dir())"
+
+          # Create parent dir for genomes tmp dir
+          echo "\$(date): Creating parent dir for genomes" 1>&2
+          # Create genomes parent directory
+          mkdir -p "$(get_genomes_parent_dir())"
+
+          # Untar umccrise genomes
+          echo "\$(date): Extracting genomes directory into scratch space" 1>&2
+          tar --directory "$(get_genomes_parent_dir())" \\
+            --extract \\
+            --file "$(inputs.genomes_tar.path)"
+
+          # Create input directories
+          mkdir -p "$(get_somatic_input_dir(inputs.dragen_somatic_directory.basename))"
+          mkdir -p "$(get_germline_input_dir(inputs.dragen_germline_directory.basename))"
+
+          # Put inputs into scratch space
+          echo "\$(date): Placing inputs into scratch space" 1>&2
+          cp -r "$(inputs.dragen_somatic_directory.path)/." "$(get_somatic_input_dir(inputs.dragen_somatic_directory.basename))/"
+          cp -r "$(inputs.dragen_germline_directory.path)/." "$(get_germline_input_dir(inputs.dragen_germline_directory.basename))/"
+
+          # Check if a bam file is in the inputs dragen germline directory path
+          if [[ "\$(find "$(get_germline_input_dir(inputs.dragen_germline_directory.basename))/" -name '*.bam' | wc -l)" == "0" ]]; then
+            echo "\$(date): No bam file in the germline directory, copying normal bam over from the tumor directory" 1>&2
+            normal_bam_somatic_src="\$( \\
+              find "$(get_somatic_input_dir(inputs.dragen_somatic_directory.basename))/" \\
+                -maxdepth 1 \\
+                -name '*_normal.bam' \\
+            )"
+            if [[ -z "\${normal_bam_somatic_src-}" ]]; then
+              echo "\$(date): Could not get normal bam file from dragen somatic directory" 1>&2
+              exit 1
+            fi
+            germline_replay_json_file="\$( \\
+              find "$(get_germline_input_dir(inputs.dragen_germline_directory.basename))/" \\
+                -maxdepth 1 \\
+                -name '*-replay.json' \\
+            )"
+            if [[ -z "\${germline_replay_json_file-}" ]]; then
+              echo "\$(date): Could not get replay json file. Could not determine germline basename" 1>&2
+              exit 1
+            fi
+            germline_basename="\$( \\
+              basename "\${germline_replay_json_file%-replay.json}" \\
+            )"
+            ln "\${normal_bam_somatic_src}" "$(get_germline_input_dir(inputs.dragen_germline_directory.basename))/\$(basename "\${germline_basename}.bam")"
+            ln "\${normal_bam_somatic_src}.bai" "$(get_germline_input_dir(inputs.dragen_germline_directory.basename))/\$(basename "\${germline_basename}.bam.bai")"
+          fi
+
+          # Run umccrise copies over inputs if umccrise failed but debug set to true
+          trap 'cleanup' EXIT
+
+          echo "\$(date): Running UMCCRise" 1>&2
+          $(get_eval_umccrise_line())
+
+          # Exit trap, exit cleanly
+          trap - EXIT
+
+          # Copy over working directory
+          echo "\$(date): UMCCRise complete, copying over outputs into output directory" 1>&2
+          cp -r "$(get_scratch_working_dir(inputs.output_directory_name))/." "$(inputs.output_directory_name)/"
+
+          echo "\$(date): Workflow complete!" 1>&2
+
+
+baseCommand: [ "bash" ]
+
+arguments:
+  # Before all other arguments
+  - position: -1
+    valueFrom: "$(get_run_script_entryname())"
+
+inputs:
+  # Input folders and files
+  dragen_somatic_directory:
+    label: dragen somatic directory
+    doc: |
+      The dragen somatic directory
+    type: Directory
+    inputBinding:
+      prefix: "--dragen_somatic_dir"
+      valueFrom: |
+        ${
+          return get_somatic_input_dir(self.basename);
+        }
+  dragen_germline_directory:
+    label: dragen germline directory
+    doc: |
+      The dragen germline directory
+    type: Directory
+    inputBinding:
+      prefix: "--dragen_germline_dir"
+      valueFrom: |
+        ${
+          return get_germline_input_dir(self.basename);
+        }
+  genomes_tar:
+    label: genomes tar
+    doc: |
+      The reference umccrise tarball
+    type: File
+    inputBinding:
+      prefix: "--genomes-dir"
+      valueFrom: "$(get_genomes_dir_path(self.basename))"
+  # Input IDs
+  subject_identifier:
+    label: subject identifier
+    doc: |
+      The subject ID (used to name output files)
+    type: string
+    inputBinding:
+      prefix: "--dragen_subject_id"
+  dragen_tumor_id:
+    label: dragen tumor id
+    doc: |
+      The name of the dragen tumor sample
+    type: string?
+    inputBinding:
+      prefix: "--dragen_tumor_id"
+  dragen_normal_id:
+    label: dragen normal id
+    doc: |
+      The name of the dragen normal sample
+    type: string?
+    inputBinding:
+      prefix: "--dragen_normal_id"
+  # Output names
+  output_directory_name:
+    label: output directory name
+    doc: |
+      The name of the output directory
+    type: string
+    inputBinding:
+      prefix: "-o"
+      valueFrom: |
+        ${
+         return get_scratch_working_dir(self);
+        }
+  # Optional inputs
+  threads:
+    label: threads
+    doc: |
+      Number of threads to use
+    type: int?
+    inputBinding:
+      prefix: "--threads"
+      valueFrom: |
+        ${
+          return get_num_threads(self, runtime.cores);
+        }
+  skip_stage:
+    label: skip stage
+    doc: |
+      Runs all default stage(s) excluding the one selected
+    type:
+      - "null"
+      - type: array
+        items: string
+        inputBinding:
+          prefix: "--skip-stage"
+    inputBinding:
+      position: 99
+  dry_run:
+    label: dry run
+    doc: |
+      Prints rules and commands to be run without actually executing them
+    type: boolean?
+    inputBinding:
+      prefix: "--dryrun"
+  include_stage:
+    label: include stage
+    doc: |
+      Optionally, specify stage(s) to run
+    type:
+      - "null"
+      - type: array
+        items: string
+        inputBinding:
+          prefix: "--stage"
+    inputBinding:
+      position: 100
+  # Debugger
+  debug:
+    label: debug
+    doc: |
+      Copy workspace to output directory if workflow fails
+    type: boolean?
+
+
+outputs:
+  output_directory:
+    label: output directory
+    doc: |
+      The output directory containing the umccrise data
+    type: Directory
+    outputBinding:
+      glob: "$(inputs.output_directory_name)"
+
+successCodes:
+  - 0


### PR DESCRIPTION
Adding umccrise v2.3.1 CWL.
I've added the `--1` suffix since I used the `--0` suffix in dev with the rc Docker tags (hope that's okay!).

- Step 1:

```bash
cwl-ica create-tool-from-template \
  --tool-name umccrise \
  --tool-version 2.3.1--1 \
  --username "Peter Diakumis"
```

- Step 2:

```bash
cwl-ica tool-validate \
  --tool-path tools/umccrise/2.3.1--1/umccrise__2.3.1--1.cwl
```

- Step 3:

```
cwl-ica tool-init \
  --tool-path tools/umccrise/2.3.1--1/umccrise__2.3.1--1.cwl --projects "development_workflows,production_workflows"
```

Extra notes (for my own sake):

There are now new umccrise entries in `config/project.yaml` under `development_workflows` and `production_workflows`, and a new umccrise entry in `config/tool.yaml`.
I suspect the `__GIT_COMMIT_ID__` under the `production_workflows` gets updated by the PR bot.
The CWL version has also been copied to `staging` and `development` from what I can see, probably via Step 3 above.