### PR TITLE
Bash var replace uses // which the typescript expression handler mist…

### DIFF
--- a/typescript-expressions/dragen-tools/4.0.3/dragen-tools__4.0.3.cwljs
+++ b/typescript-expressions/dragen-tools/4.0.3/dragen-tools__4.0.3.cwljs
@@ -498,7 +498,7 @@ function get_md5sum_fastq_raw_script(fastq_list_rows, input_directory) {
     get_md5sum_fastq_raw_script_contents += "# Generate md5sums for the input fastq gz files\n";
     get_md5sum_fastq_raw_script_contents += "for fastq_gz_path in \"${FASTQ_GZ_PATHS[@]}\"; do\n";
     get_md5sum_fastq_raw_script_contents += "  full_input_path=\"".concat(input_directory.path, "/${fastq_gz_path}\"\n");
-    get_md5sum_fastq_raw_script_contents += "  zcat \"${full_input_path}\" | md5sum | sed \"s%-%${fastq_gz_path/* .gz/}%\"\n"; */
+    get_md5sum_fastq_raw_script_contents += "  zcat \"${full_input_path}\" | md5sum | sed \"s%-%${fastq_gz_path%.gz}%\"\n";
     get_md5sum_fastq_raw_script_contents += "done\n\n";
     get_md5sum_fastq_raw_script_contents += "# Md5sum script complete\n";
     return {

--- a/typescript-expressions/dragen-tools/4.0.3/dragen-tools__4.0.3.js
+++ b/typescript-expressions/dragen-tools/4.0.3/dragen-tools__4.0.3.js
@@ -540,7 +540,7 @@ function get_md5sum_fastq_raw_script(fastq_list_rows, input_directory) {
     get_md5sum_fastq_raw_script_contents += "# Generate md5sums for the input fastq gz files\n";
     get_md5sum_fastq_raw_script_contents += "for fastq_gz_path in \"${FASTQ_GZ_PATHS[@]}\"; do\n";
     get_md5sum_fastq_raw_script_contents += "  full_input_path=\"".concat(input_directory.path, "/${fastq_gz_path}\"\n");
-    get_md5sum_fastq_raw_script_contents += "  zcat \"${full_input_path}\" | md5sum | sed \"s%-%${fastq_gz_path//.gz/}%\"\n";
+    get_md5sum_fastq_raw_script_contents += "  zcat \"${full_input_path}\" | md5sum | sed \"s%-%${fastq_gz_path%.gz}%\"\n";
     get_md5sum_fastq_raw_script_contents += "done\n\n";
     get_md5sum_fastq_raw_script_contents += "# Md5sum script complete\n";
     return {

--- a/typescript-expressions/dragen-tools/4.0.3/dragen-tools__4.0.3.ts
+++ b/typescript-expressions/dragen-tools/4.0.3/dragen-tools__4.0.3.ts
@@ -599,7 +599,7 @@ export function get_md5sum_fastq_raw_script(fastq_list_rows: FastqListRow[], inp
     get_md5sum_fastq_raw_script_contents += `# Generate md5sums for the input fastq gz files\n`
     get_md5sum_fastq_raw_script_contents += `for fastq_gz_path in "\${FASTQ_GZ_PATHS[@]}"; do\n`
     get_md5sum_fastq_raw_script_contents += `  full_input_path="${input_directory.path}/\${fastq_gz_path}"\n`
-    get_md5sum_fastq_raw_script_contents += `  zcat "\${full_input_path}" | md5sum | sed "s%-%\${fastq_gz_path//.gz/}%"\n`
+    get_md5sum_fastq_raw_script_contents += `  zcat "\${full_input_path}" | md5sum | sed "s%-%\${fastq_gz_path%.gz}%"\n`
     get_md5sum_fastq_raw_script_contents += `done\n\n`
 
     get_md5sum_fastq_raw_script_contents += `# Md5sum script complete\n`

--- a/typescript-expressions/dragen-tools/4.0.3/tests/data/generate-md5sum-for-fastq-raw-files.sh
+++ b/typescript-expressions/dragen-tools/4.0.3/tests/data/generate-md5sum-for-fastq-raw-files.sh
@@ -14,7 +14,7 @@ FASTQ_GZ_PATHS=(
 # Generate md5sums for the input fastq gz files
 for fastq_gz_path in "${FASTQ_GZ_PATHS[@]}"; do
   full_input_path="data/${fastq_gz_path}"
-  zcat "${full_input_path}" | md5sum | sed "s%-%${fastq_gz_path//.gz/}%"
+  zcat "${full_input_path}" | md5sum | sed "s%-%${fastq_gz_path%.gz}%"
 done
 
 # Md5sum script complete

--- a/typescript-expressions/dragen-tools/4.0.3/tests/dragen-tools__4.0.3.test.js
+++ b/typescript-expressions/dragen-tools/4.0.3/tests/dragen-tools__4.0.3.test.js
@@ -23,7 +23,7 @@ var TUMOR_FASTQ_LIST_CSV_FILE_PATH = "tests/data/tumor_fastq_list.csv";
 var ORA_FASTQ_LIST_CSV_FILE_PATH = "tests/data/fastq_list.ora.csv";
 var MV_ORA_FILE_PATH = "tests/data/mv-ora.sh";
 var GENERATE_NEW_FASTQ_LIST_CSV_SH_PATH = "tests/data/generate-new-fastq-list-csv.sh";
-var GENERATE_MD5SUM_FOR_FASTQ_GZ_FILES_SH_PATH = "tests/data/generate-md5sum-for-fastq-raw-files.sh";
+var GENERATE_MD5SUM_FOR_FASTQ_RAW_FILES_SH_PATH = "tests/data/generate-md5sum-for-fastq-raw-files.sh";
 var GENERATE_MD5SUM_FOR_FASTQ_ORA_FILES_SH_PATH = "tests/data/generate-md5sum-for-fastq-ora-files.sh";
 var GENERATE_FILE_SIZES_FOR_FASTQ_GZ_FILES_SH_PATH = "tests/data/generate-file-sizes-for-fastq-gz-files.sh";
 var GENERATE_FILE_SIZES_FOR_FASTQ_ORA_FILES_SH_PATH = "tests/data/generate-file-sizes-for-fastq-ora-files.sh";
@@ -182,10 +182,10 @@ var EXPECTED_ORA_NEW_FASTQ_LIST_CSV_SH_OUTPUT = {
     basename: "generate-new-fastq-list-csv.sh",
     contents: (0, fs_1.readFileSync)(GENERATE_NEW_FASTQ_LIST_CSV_SH_PATH, "utf8")
 };
-var EXPECTED_MD5SUM_FOR_FASTQ_GZ_FILES_SH_OUTPUT = {
+var EXPECTED_MD5SUM_FOR_FASTQ_RAW_FILES_SH_OUTPUT = {
     class_: cwl_ts_auto_1.File_class.FILE,
     basename: "generate-md5sum-for-fastq-raw-files.sh",
-    contents: (0, fs_1.readFileSync)(GENERATE_MD5SUM_FOR_FASTQ_GZ_FILES_SH_PATH, "utf8")
+    contents: (0, fs_1.readFileSync)(GENERATE_MD5SUM_FOR_FASTQ_RAW_FILES_SH_PATH, "utf8")
 };
 var EXPECTED_MD5SUM_FOR_FASTQ_ORA_FILES_SH_OUTPUT = {
     class_: cwl_ts_auto_1.File_class.FILE,
@@ -344,7 +344,7 @@ describe('Test ora mount points', function () {
         },
         {
             "entryname": "generate-md5sum-for-fastq-raw-files.sh",
-            "entry": EXPECTED_MD5SUM_FOR_FASTQ_GZ_FILES_SH_OUTPUT
+            "entry": EXPECTED_MD5SUM_FOR_FASTQ_RAW_FILES_SH_OUTPUT
         },
         {
             "entryname": "generate-file-sizes-for-fastq-gz-files.sh",

--- a/typescript-expressions/dragen-tools/4.0.3/tests/dragen-tools__4.0.3.test.ts
+++ b/typescript-expressions/dragen-tools/4.0.3/tests/dragen-tools__4.0.3.test.ts
@@ -40,7 +40,7 @@ const TUMOR_FASTQ_LIST_CSV_FILE_PATH = "tests/data/tumor_fastq_list.csv";
 const ORA_FASTQ_LIST_CSV_FILE_PATH = "tests/data/fastq_list.ora.csv"
 const MV_ORA_FILE_PATH = "tests/data/mv-ora.sh"
 const GENERATE_NEW_FASTQ_LIST_CSV_SH_PATH = "tests/data/generate-new-fastq-list-csv.sh"
-const GENERATE_MD5SUM_FOR_FASTQ_GZ_FILES_SH_PATH = "tests/data/generate-md5sum-for-fastq-raw-files.sh"
+const GENERATE_MD5SUM_FOR_FASTQ_RAW_FILES_SH_PATH = "tests/data/generate-md5sum-for-fastq-raw-files.sh"
 const GENERATE_MD5SUM_FOR_FASTQ_ORA_FILES_SH_PATH = "tests/data/generate-md5sum-for-fastq-ora-files.sh"
 const GENERATE_FILE_SIZES_FOR_FASTQ_GZ_FILES_SH_PATH = "tests/data/generate-file-sizes-for-fastq-gz-files.sh"
 const GENERATE_FILE_SIZES_FOR_FASTQ_ORA_FILES_SH_PATH = "tests/data/generate-file-sizes-for-fastq-ora-files.sh"
@@ -200,10 +200,10 @@ const EXPECTED_ORA_NEW_FASTQ_LIST_CSV_SH_OUTPUT: IFile = {
     basename: "generate-new-fastq-list-csv.sh",
     contents: readFileSync(GENERATE_NEW_FASTQ_LIST_CSV_SH_PATH, "utf8")
 };
-const EXPECTED_MD5SUM_FOR_FASTQ_GZ_FILES_SH_OUTPUT: IFile = {
+const EXPECTED_MD5SUM_FOR_FASTQ_RAW_FILES_SH_OUTPUT: IFile = {
     class_: File_class.FILE,
     basename: "generate-md5sum-for-fastq-raw-files.sh",
-    contents: readFileSync(GENERATE_MD5SUM_FOR_FASTQ_GZ_FILES_SH_PATH, "utf8")
+    contents: readFileSync(GENERATE_MD5SUM_FOR_FASTQ_RAW_FILES_SH_PATH, "utf8")
 };
 const EXPECTED_MD5SUM_FOR_FASTQ_ORA_FILES_SH_OUTPUT: IFile = {
     class_: File_class.FILE,
@@ -371,7 +371,7 @@ describe('Test ora mount points', function () {
         },
         {
             "entryname": "generate-md5sum-for-fastq-raw-files.sh",
-            "entry": EXPECTED_MD5SUM_FOR_FASTQ_GZ_FILES_SH_OUTPUT
+            "entry": EXPECTED_MD5SUM_FOR_FASTQ_RAW_FILES_SH_OUTPUT
         },
         {
             "entryname": "generate-file-sizes-for-fastq-gz-files.sh",

--- a/typescript-expressions/dragen-tools/4.0.3/tests/summary.txt
+++ b/typescript-expressions/dragen-tools/4.0.3/tests/summary.txt
@@ -1,4 +1,4 @@
-# Test started at 2024-11-15T15:25:57+11:00
+# Test started at 2024-11-15T17:43:41+11:00
 
 PASS tests/dragen-tools__4.0.3.test.js
   ● Console
@@ -43,7 +43,7 @@ Lines        : 88.31% ( 310/351 )
 Test Suites: 1 failed, 1 passed, 2 total
 Tests:       16 passed, 16 total
 Snapshots:   0 total
-Time:        2.126 s
+Time:        1.751 s
 Ran all test suites.
-# Test completed at 2024-11-15T15:26:01+11:00
+# Test completed at 2024-11-15T17:43:44+11:00
 


### PR DESCRIPTION
…akes as a comment

// comments are converted to /*comment*/ to allow for cwl java script to occur all as one long string.

As such the bash var is subbed out