### PR TITLE
Add option vc-max-callable-region-memory-usage option

### DIFF
--- a/schemas/dragen-snv-variant-caller-options/4.4.4/dragen-snv-variant-caller-options__4.4.4.yaml
+++ b/schemas/dragen-snv-variant-caller-options/4.4.4/dragen-snv-variant-caller-options__4.4.4.yaml
@@ -222,3 +222,9 @@ fields:
       Recommended way to run contamination detection based on GATK CalculateContamination.
       Supports germline and somatic.
     type: boolean?
+  # High Coverage analysis options
+  vc_max_callable_region_memory_usage:
+    label: vc max callable region memory usage
+    doc: |
+      Set the maximum size of a single callable region. Default is "13GB".
+    type: str?


### PR DESCRIPTION
For high coverage analysis - https://help.dragen.illumina.com/product-guide/dragen-v4.4/dragen-dna-pipeline/high-coverage?ask=vc-allocator-size&q=vc-allocator-size#command-line-options

Had a few samples fail, and default is set to 13 GB which IMO is too high. 
Will try setting to 12 GB and should be safer for somatic samples